### PR TITLE
Fix path for private company data and train check

### DIFF
--- a/app/base.py
+++ b/app/base.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from enum import Enum
 from functools import reduce
@@ -316,7 +317,6 @@ class PrivateCompany:
 
     @staticmethod
     def allPrivateCompanies() -> List["PrivateCompany"]:
-        import os
         data_path = os.path.join(os.path.dirname(__file__), 'data', 'private_companies')
         with open(data_path) as f:
             content = f.readlines()

--- a/app/base.py
+++ b/app/base.py
@@ -287,7 +287,7 @@ class PublicCompany:
         return self._floated
 
     def hasNoTrains(self) -> bool:
-        return len(self.trains) > 0
+        return len(self.trains) == 0
 
     def hasValidRoute(self) -> bool:
         # TODO You need to have a train if you have a valid route
@@ -316,7 +316,9 @@ class PrivateCompany:
 
     @staticmethod
     def allPrivateCompanies() -> List["PrivateCompany"]:
-        with open('/Users/jawaad/PycharmProjects/Daemon1830/app/data/private_companies') as f:
+        import os
+        data_path = os.path.join(os.path.dirname(__file__), 'data', 'private_companies')
+        with open(data_path) as f:
             content = f.readlines()
         return [PrivateCompany.initiate(*c.strip().split("|")) for c in content]
 


### PR DESCRIPTION
## Summary
- load private company data using a repo-relative path
- fix `hasNoTrains` to return True when a company has zero trains

## Testing
- `python -m unittest app.unittests.PrivateCompanyMinigameTests -v`
- `python -m unittest app.unittests.BiddingForPrivateCompanyMinigameTests -v`
- `python -m unittest app.unittests.StockRoundMinigameTests -v`
- `python -m unittest app.unittests.SellPrivateCompanyAuctionTests -v`
