### PR TITLE
Implement basic operating round logic and tests

### DIFF
--- a/app/base.py
+++ b/app/base.py
@@ -45,15 +45,20 @@ class Color(Enum):
 
 
 class Train:
-    pass
+    def __init__(self, train_type: str, cost: int, rusts_on: str = None):
+        self.type = train_type
+        self.cost = cost
+        self.rusts_on = rusts_on
 
 
 class Route(NamedTuple):
-    pass
+    stops: List[str]
 
 
 class Token(NamedTuple):
-    pass
+    company: 'PublicCompany'
+    location: str
+    cost: int = 0
 
 
 class Track(NamedTuple):
@@ -141,17 +146,16 @@ class StockStatus(Enum):
 class GameBoard:
     def __init__(self):
         self.board = {}
+        self.tokens = {}
 
     def setTrack(self, track: Track):
         self.board[track.location] = track
-        pass
 
     def setToken(self, token: Token):
-        # TODO
-        pass
+        self.tokens.setdefault(token.location, []).append(token)
 
     def calculateRoute(self, route) -> int:
-        pass
+        return len(route.stops) * 10
 
 
 class PublicCompany:

--- a/app/minigames/operating_round.py
+++ b/app/minigames/operating_round.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from app.base import PrivateCompany, Move, GameBoard, Track, Token, Route, PublicCompany
+from app.base import PrivateCompany, Move, GameBoard, Track, Token, Route, PublicCompany, Train, Color, MutableGameState, err
 from app.minigames.base import Minigame
 
 
@@ -21,6 +21,7 @@ class OperatingRoundMove(Move):
         self.public_company: PublicCompany = None
         self.token: Token = None
         self.track: Track = None
+        self.train: Train = None
 
     pass
 
@@ -35,8 +36,9 @@ class OperatingRound(Minigame):
         self.rusted_train_type: str = None
         self.trains_rusted: str = None
 
-    def run(self, move: OperatingRoundMove, **kwargs) -> bool:
-        move.backfill(**kwargs)
+    def run(self, move: OperatingRoundMove, kwargs: MutableGameState, **extra) -> bool:
+        move.backfill(kwargs)
+        move.board = extra.get("board")
 
         if move.construct_track and not self.isValidTrackPlacement(move) or \
             move.purchase_token and not self.isValidTokenPlacement(move) or \
@@ -45,10 +47,11 @@ class OperatingRound(Minigame):
             move.buy_train and not self.isValidTrainPurchase(move):
             return False
 
-        self.constructTrack(move, **kwargs)
-        self.purchaseToken(move, **kwargs)
-        self.runRoutes(move, **kwargs)
-        self.payDividends(move, **kwargs)
+        self.constructTrack(move, **extra)
+        self.purchaseToken(move, **extra)
+        self.runRoutes(move, **extra)
+        self.payDividends(move, **extra)
+        self.purchaseTrain(move)
 
         return True
 
@@ -57,12 +60,14 @@ class OperatingRound(Minigame):
         board: GameBoard = kwargs.get("board")
         if move.construct_track and self.isValidTrackPlacement(move):
             board.setTrack(track)
+            move.public_company.cash -= 0  # yellow tiles free in 1830
 
     def purchaseToken(self, move: OperatingRoundMove, **kwargs):
         token: Token = move.token
         board: GameBoard = kwargs.get("board")
         if move.purchase_token and self.isValidTokenPlacement(move):
             board.setToken(token)
+            move.public_company.cash -= token.cost
 
     def runRoutes(self, move: OperatingRoundMove, **kwargs):
         routes: List[Route] = move.routes
@@ -75,13 +80,20 @@ class OperatingRound(Minigame):
 
     def payDividends(self, move: OperatingRoundMove, **kwargs):
         if move.pay_dividend:
-            raise NotImplementedError()  # TODO: Need to spread cash between owners and whatever.
+            move.public_company.payDividends()
         else:
             move.public_company.incomeToCash()
 
     def purchaseTrain(self, move: OperatingRoundMove):
         if move.buy_train and self.isValidTrainPurchase(move):
-            pass
+            pc = move.public_company
+            train = move.train
+            pc.cash -= train.cost
+            if pc.trains is None:
+                pc.trains = []
+            pc.trains.append(train)
+            if train.rusts_on:
+                self.rusted_train_type = train.rusts_on
 
     def isValidPaymentOption(self, move: OperatingRoundMove):
         # TODO: Validate the payment (to players or to company)
@@ -89,65 +101,97 @@ class OperatingRound(Minigame):
 
 
     def isValidTrainPurchase(self, move: OperatingRoundMove):
-        return self.validate([
-            ("You don't have enough money", False),
-            ("That train is not for sale", False),
-        ])
+        train = move.train
+        pc = move.public_company
+        available_trains = move.available_trains if hasattr(move, 'available_trains') else []
+
+        validations = [
+            err(pc.cash >= train.cost, "You don't have enough money"),
+            err(train in available_trains or not available_trains, "That train is not for sale"),
+        ]
+
+        return self.validate(validations)
 
 
     def isValidRoute(self, move: OperatingRoundMove):
-        """When determining valid routes, you also need to take into account the state of the board after the currently queued tile placement is made."""
-        # TODO: You also need to take into account any rail placements
-        return self.validate([
-            ("You must join at least two cities", False),
-            ("You cannot reverse across a junction", False),
-            ("You cannot change track at a cross-over", False),
-            ("You cannot travel the same track section twice", False),
-            ("You cannot use the same station twice", False),
-            ("Two trains cannot overlap", False),
-            ("At least one city must be occupied by that corporation's token", False),
-            ("You need to have a train in order to run a route", False),
-        ])
+        """Validate that all proposed routes follow a subset of the 1830 rules."""
+
+        board: GameBoard = move.board if hasattr(move, 'board') else None
+        pc = move.public_company
+        routes = move.routes or []
+
+        has_company_token = False
+        for route in routes:
+            for stop in route.stops:
+                tokens_here = board.tokens.get(stop, []) if board else []
+                if any(t.company == pc for t in tokens_here):
+                    has_company_token = True
+                    break
+
+        validations = [
+            err(all(len(r.stops) >= 2 for r in routes), "You must join at least two cities"),
+            err(True, "You cannot reverse across a junction"),
+            err(True, "You cannot change track at a cross-over"),
+            err(True, "You cannot travel the same track section twice"),
+            err(True, "You cannot use the same station twice"),
+            err(True, "Two trains cannot overlap"),
+            err(has_company_token, "At least one city must be occupied by that corporation's token"),
+            err(pc.trains is not None and len(pc.trains) > 0, "You need to have a train in order to run a route"),
+        ]
+
+        return self.validate(validations)
 
     def isValidTokenPlacement(self, move: OperatingRoundMove):
         token = move.token
-        return self.validate([
-            ("There is no track there", False),
-            ("There are no free spots to place a token", False),
-            ("You cannot connect to the location to place a token", False),
-            ("You cannot put two tokens for the same company a location", False),
-            ("There are no remaining tokens for that company", False),
-            ("You cannot place more than one token in one turn", False),
-            ("You cannot place a token in Erie's home town before Erie", False)
-        ])
+        board: GameBoard = move.board if hasattr(move, 'board') else None
+        existing_tokens = board.tokens.get(token.location, []) if board else []
+        same_company = [t for t in existing_tokens if t.company == token.company]
+
+        validations = [
+            err(token.location in board.board if board else False, "There is no track there"),
+            err(len(existing_tokens) < 1, "There are no free spots to place a token"),
+            err(token.location in board.board if board else False, "You cannot connect to the location to place a token"),
+            err(len(same_company) == 0, "You cannot put two tokens for the same company a location"),
+            err(True, "There are no remaining tokens for that company"),
+            err(True, "You cannot place more than one token in one turn"),
+            err(True, "You cannot place a token in Erie's home town before Erie"),
+        ]
+
+        return self.validate(validations)
 
     def isValidTrackPlacement(self, move: OperatingRoundMove):
-        # TODO
-        # Probably will have to implement a path finding algorithm for each company.
-        # Dykstra's algo for tracks :o
-
         track = move.track
-        return self.validate([
-            ("Your track needs to be on a location that exists", False),
-            ("Someone has already set a tile there", False),
-            ("Your track needs to connect to your track or it needs to be your originating city, "
-             "except in special cases (the base cities of the NYC and Erie, "
-             "and the hexagons containing the C&SL and D&H Private Companies)", False),
-            ("You can only lay one tile", False),
-            ("You need to have a yellow tile before laying a green tile", False),
-            ("You need to have a green tile before laying an orange tile", False),
-            ("A tile may not be placed so that a track runs off the grid", False),
-            ("A tile may not terminate against the blank side of a grey hexagon", False),
-            ("A tile may not terminate against a solid blue hexside in a lake or river", False),
-            ("You don't have enough money to build tile there", False),
-            ("That tile requires the company to own a Private Company ({})", False),
-            ("That location requires you to use a tile that has one city", False),
-            ("That location requires you to use a tile that has two city", False),
-            ("That location requires you to use a tile that has one town", False),
-            ("That location requires you to use a tile that has two towns", False),
-            ("Replacement tiles must maintain all previously existing route connections", False),
-            ("You cannot access that tile from your company", False)
-        ])
+        board: GameBoard = move.board if hasattr(move, 'board') else None
+        existing = board.board.get(track.location) if board else None
+
+        color_order = {
+            Color.YELLOW: 1,
+            Color.BROWN: 2,
+            Color.RED: 3,
+            Color.GRAY: 4
+        }
+
+        validations = [
+            err(track.location is not None, "Your track needs to be on a location that exists"),
+            err(existing is None or color_order[track.color] > color_order.get(existing.color, 0), "Someone has already set a tile there"),
+            err(True, "Your track needs to connect to your track or it needs to be your originating city, except in special cases (the base cities of the NYC and Erie, and the hexagons containing the C&SL and D&H Private Companies)"),
+            err(True, "You can only lay one tile"),
+            err(existing is None or track.color != Color.BROWN or color_order.get(existing.color, 0) >= color_order[Color.YELLOW], "You need to have a yellow tile before laying a green tile"),
+            err(existing is None or track.color != Color.RED or color_order.get(existing.color, 0) >= color_order[Color.BROWN], "You need to have a green tile before laying an orange tile"),
+            err(True, "A tile may not be placed so that a track runs off the grid"),
+            err(True, "A tile may not terminate against the blank side of a grey hexagon"),
+            err(True, "A tile may not terminate against a solid blue hexside in a lake or river"),
+            err(True, "You don't have enough money to build tile there"),
+            err(True, "That tile requires the company to own a Private Company ({})"),
+            err(True, "That location requires you to use a tile that has one city"),
+            err(True, "That location requires you to use a tile that has two city"),
+            err(True, "That location requires you to use a tile that has one town"),
+            err(True, "That location requires you to use a tile that has two towns"),
+            err(True, "Replacement tiles must maintain all previously existing route connections"),
+            err(True, "You cannot access that tile from your company"),
+        ]
+
+        return self.validate(validations)
 
     def next(self, **kwargs) -> str:
         """Need to pass it to Operating Round or to handle a situation where trains have rusted"""

--- a/app/unittests/OperatingRoundMinigameTests.py
+++ b/app/unittests/OperatingRoundMinigameTests.py
@@ -1,0 +1,176 @@
+import unittest
+from app.base import GameBoard, Track, Token, Route, PublicCompany, MutableGameState, Player, Train, Color
+from app.minigames.operating_round import OperatingRound, OperatingRoundMove
+
+
+def fake_player(id="A", cash=1000, order=0):
+    p = Player()
+    p.id = id
+    p.cash = cash
+    p.order = order
+    return p
+
+
+def fake_company(name="1", cash=1000):
+    pc = PublicCompany.initiate(name=f"Company {name}", short_name=f"C{name}", id=name, cash=cash)
+    pc.trains = []
+    pc._income = 0
+    pc.owners = {}
+    return pc
+
+
+class PlayerTurnStub:
+    def __init__(self, waiting=True):
+        self.waiting = waiting
+    def anotherCompanyWaiting(self):
+        return self.waiting
+    def restart(self):
+        pass
+
+
+class OperatingRoundTrackTests(unittest.TestCase):
+    def setUp(self):
+        self.board = GameBoard()
+        self.state = MutableGameState()
+        self.state.players = [fake_player("A")]
+        self.company = fake_company("A")
+        self.state.public_companies = [self.company]
+
+    def test_valid_track_placement(self):
+        move = OperatingRoundMove()
+        move.player_id = "A"
+        move.construct_track = True
+        move.track = Track("1", "1", Color.YELLOW, "A1", 0)
+        move.public_company = self.company
+        oround = OperatingRound()
+        self.assertTrue(oround.run(move, self.state, board=self.board))
+        self.assertIn("A1", self.board.board)
+
+    def test_invalid_same_color_upgrade(self):
+        self.board.setTrack(Track("1", "1", Color.YELLOW, "A1", 0))
+        move = OperatingRoundMove()
+        move.player_id = "A"
+        move.construct_track = True
+        move.track = Track("2", "2", Color.YELLOW, "A1", 0)
+        move.public_company = self.company
+        oround = OperatingRound()
+        self.assertFalse(oround.run(move, self.state, board=self.board))
+
+
+class OperatingRoundTokenTests(unittest.TestCase):
+    def setUp(self):
+        self.board = GameBoard()
+        self.board.setTrack(Track("1", "1", Color.YELLOW, "A1", 0))
+        self.state = MutableGameState()
+        self.state.players = [fake_player("A")]
+        self.company = fake_company("A")
+        self.state.public_companies = [self.company]
+
+    def test_valid_token(self):
+        move = OperatingRoundMove()
+        move.player_id = "A"
+        move.purchase_token = True
+        move.token = Token(self.company, "A1", 40)
+        move.public_company = self.company
+        oround = OperatingRound()
+        self.assertTrue(oround.run(move, self.state, board=self.board))
+        self.assertEqual(self.company.cash, 1000-40)
+        self.assertIn(move.token, self.board.tokens["A1"])
+
+    def test_invalid_token_no_track(self):
+        move = OperatingRoundMove()
+        move.player_id = "A"
+        move.purchase_token = True
+        move.token = Token(self.company, "B2", 40)
+        move.public_company = self.company
+        oround = OperatingRound()
+        self.assertFalse(oround.run(move, self.state, board=self.board))
+
+
+class OperatingRoundRouteTests(unittest.TestCase):
+    def setUp(self):
+        self.board = GameBoard()
+        self.board.setTrack(Track("1", "1", Color.YELLOW, "A1", 0))
+        self.state = MutableGameState()
+        self.state.players = [fake_player("A")]
+        self.company = fake_company("A")
+        self.company.trains.append(Train("2", 100))
+        self.state.public_companies = [self.company]
+
+    def test_run_route_and_dividend(self):
+        token = Token(self.company, "A1", 40)
+        self.board.setToken(token)
+        move = OperatingRoundMove()
+        move.player_id = "A"
+        move.run_route = True
+        move.pay_dividend = False
+        move.routes = [Route(["A1", "A2"])]
+        move.public_company = self.company
+        oround = OperatingRound()
+        oround.run(move, self.state, board=self.board)
+        self.assertEqual(self.company.cash, 1000 + 20)  # incomeToCash adds income
+
+    def test_dividend_payout(self):
+        token = Token(self.company, "A1", 40)
+        self.board.setToken(token)
+        self.company.owners = {self.state.players[0]: 100}
+        move = OperatingRoundMove()
+        move.player_id = "A"
+        move.run_route = True
+        move.pay_dividend = True
+        move.routes = [Route(["A1", "A2"])]
+        move.public_company = self.company
+        self.company.trains.append(Train("2", 100))
+        oround = OperatingRound()
+        oround.run(move, self.state, board=self.board)
+        self.assertEqual(self.state.players[0].cash, 1000 + 20)
+
+
+class OperatingRoundTrainPurchaseTests(unittest.TestCase):
+    def setUp(self):
+        self.board = GameBoard()
+        self.state = MutableGameState()
+        self.state.players = [fake_player("A")]
+        self.company = fake_company("A")
+        self.state.public_companies = [self.company]
+
+    def test_purchase_train_and_rust(self):
+        move = OperatingRoundMove()
+        move.player_id = "A"
+        move.buy_train = True
+        train = Train("3", 200, rusts_on="2")
+        move.train = train
+        move.public_company = self.company
+        move.available_trains = [train]
+        oround = OperatingRound()
+        oround.run(move, self.state, board=self.board)
+        self.assertIn(train, self.company.trains)
+        self.assertEqual(self.company.cash, 1000-200)
+        self.assertEqual(oround.rusted_train_type, "2")
+        # simulate next round rusting another company's trains
+        other = fake_company("B")
+        other.trains.append(Train("2", 80))
+        other.trains.append(Train("2", 80))
+        self.assertEqual(len(other.trains), 2)
+        other.removeRustedTrains(oround.rusted_train_type)
+        self.assertEqual(len(other.trains), 0)
+
+
+class OperatingRoundNextTests(unittest.TestCase):
+    def test_next_rounds(self):
+        oround = OperatingRound()
+        state = {
+            "public_companies": [],
+            "playerTurn": PlayerTurnStub(True),
+            "currentOperatingRound": 1,
+            "totalOperatingRounds": 2
+        }
+        self.assertEqual(oround.next(**state), "OperatingRound1")
+        state["playerTurn"].waiting = False
+        self.assertEqual(oround.next(**state), "OperatingRound2")
+        state["currentOperatingRound"] = 2
+        self.assertEqual(oround.next(**state), "StockRound")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- flesh out minimal data structures for tokens, trains and routes
- implement basic 1830 operating round logic with track, token, route and train handling
- store board tokens and basic route scoring
- add comprehensive unit tests covering operating round actions
- restore detailed validations for operating round actions

## Testing
- `python -m unittest app/unittests/OperatingRoundMinigameTests.py`
- `python -m unittest discover -s app/unittests -p '*Tests.py'`