### PR TITLE
Add game variant configuration layer

### DIFF
--- a/app/config/1830.py
+++ b/app/config/1830.py
@@ -1,0 +1,21 @@
+from app.base import PrivateCompany, Train
+
+
+def starting_cash(num_players: int) -> int:
+    return int(2400 / num_players)
+
+
+PRIVATE_COMPANIES = [
+    PrivateCompany.initiate(1, "Schuylkill Valley Railroad & Navigation Company", "SVR", 20, 5, "G15"),
+    PrivateCompany.initiate(2, "Champlain & St.Lawrence Railway", "C&StL", 40, 10, "B20"),
+    PrivateCompany.initiate(3, "Delaware & Hudson Railroad", "D&H", 70, 15, "F16"),
+    PrivateCompany.initiate(4, "Mohawk & Hudson Railroad", "M&H", 110, 20, "D18"),
+    PrivateCompany.initiate(5, "Camden & Amboy Railroad", "C&A", 160, 25, "H18"),
+    PrivateCompany.initiate(6, "Baltimore & Ohio Railroad", "B&O", 220, 30, "I13/I15"),
+]
+
+# Placeholder data for future rules
+STOCK_MARKET = []
+TRAINS = [Train("2", 80, rusts_on="4"), Train("3", 180, rusts_on="5")]
+OPERATING_ROUNDS = 2
+

--- a/app/config/1846.py
+++ b/app/config/1846.py
@@ -1,0 +1,19 @@
+from app.base import PrivateCompany, Train
+
+
+def starting_cash(num_players: int) -> int:
+    return int(3000 / num_players)
+
+
+PRIVATE_COMPANIES = [
+    PrivateCompany.initiate(1, "Mail Contract", "MC", 40, 5, "A1"),
+    PrivateCompany.initiate(2, "Steamboat Company", "SB", 80, 10, "B2"),
+    PrivateCompany.initiate(3, "Meat Packing", "MP", 120, 15, "C3"),
+    PrivateCompany.initiate(4, "Lake Shore Line", "LSL", 200, 20, "D4"),
+]
+
+# Placeholder data for future rules
+STOCK_MARKET = []
+TRAINS = [Train("2", 100, rusts_on="4"), Train("3", 200, rusts_on="6")]
+OPERATING_ROUNDS = 2
+

--- a/app/config/1889.py
+++ b/app/config/1889.py
@@ -1,0 +1,19 @@
+from app.base import PrivateCompany, Train
+
+
+def starting_cash(num_players: int) -> int:
+    return int(2500 / num_players)
+
+
+PRIVATE_COMPANIES = [
+    PrivateCompany.initiate(1, "Shinano Railway", "SR", 20, 5, "Z1"),
+    PrivateCompany.initiate(2, "Iyo Railway", "IR", 40, 10, "Z2"),
+    PrivateCompany.initiate(3, "Osaka Railway", "OR", 80, 15, "Z3"),
+    PrivateCompany.initiate(4, "Kyushu Steamship", "KS", 160, 20, "Z4"),
+    PrivateCompany.initiate(5, "Hokkaido Coal", "HC", 200, 25, "Z5"),
+]
+
+STOCK_MARKET = []
+TRAINS = [Train("2", 90, rusts_on="4"), Train("3", 180, rusts_on="6")]
+OPERATING_ROUNDS = 2
+

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -1,0 +1,5 @@
+import importlib
+
+def load_config(name: str):
+    """Dynamically load a rules configuration module."""
+    return importlib.import_module(f'app.config.{name}')

--- a/app/example.py
+++ b/app/example.py
@@ -14,7 +14,7 @@ from app.minigames.PrivateCompanyInitialAuction.move import BuyPrivateCompanyMov
 def example() -> Game:
     """Run a tiny example game and return the final state."""
     players = ["Alice", "Bob"]
-    game = Game.start(players)
+    game = Game.start(players, variant="1830")
     game.setPlayerOrder()
     game.setCurrentPlayer()
 

--- a/app/state.py
+++ b/app/state.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from app.config import load_config
+
 import logging
 
 from app.base import err, Player, Move, PrivateCompany, PublicCompany, MutableGameState
@@ -90,21 +92,22 @@ class Game:
     
     """
     @staticmethod
-    def start(players: List[str]) -> "Game":
+    def start(players: List[str], variant: str = "1830") -> "Game":
+        config = load_config(variant)
         total_players = len(players)
-        cash = int(2400 / total_players)
+        cash = config.starting_cash(total_players)
         player_objects = []
         for order, player_name in enumerate(players):
             player_objects.append(
                 Player.create(player_name, cash, order)
             )
-        game = Game.initialize(player_objects)
+        game = Game.initialize(player_objects, config)
         game.setMinigame("BuyPrivateCompany")
         return game
 
 
     @staticmethod
-    def initialize(players: List[Player], saved_game: dict = None) -> "Game":
+    def initialize(players: List[Player], config, saved_game: dict = None) -> "Game":
         """
 
         :param players:
@@ -112,9 +115,10 @@ class Game:
         :return:
         """
         game = Game()
+        game.config = config
         game.state = MutableGameState()
         game.state.players = players
-        game.state.private_companies = PrivateCompany.allPrivateCompanies()
+        game.state.private_companies = config.PRIVATE_COMPANIES
         game.state.public_companies = []
 
         return game
@@ -124,6 +128,7 @@ class Game:
         self.current_player: Player = None
         self.player_order_fn_list = []
         self.errors_list = []
+        self.config = None
 
     def isOngoing(self) -> bool:
         return True

--- a/app/unittests/GameStateTransitionTests.py
+++ b/app/unittests/GameStateTransitionTests.py
@@ -8,7 +8,7 @@ from app.minigames.PrivateCompanyInitialAuction.move import BuyPrivateCompanyMov
 
 class GameStateTransitionTests(unittest.TestCase):
     def test_apply_move_returns_updated_state(self):
-        game = Game.start(["Alice", "Bob"])
+        game = Game.start(["Alice", "Bob"], variant="1830")
         game.setPlayerOrder()
         game.setCurrentPlayer()
         state = game.getState()

--- a/app/unittests/GameVariantLoadingTests.py
+++ b/app/unittests/GameVariantLoadingTests.py
@@ -1,0 +1,31 @@
+import unittest
+
+from app.state import Game
+from app.config import load_config
+
+
+class GameVariantLoadingTests(unittest.TestCase):
+    def test_1830_config(self):
+        cfg = load_config("1830")
+        game = Game.start(["A", "B", "C", "D"], variant="1830")
+        self.assertEqual(game.state.players[0].cash, cfg.starting_cash(4))
+        self.assertEqual([pc.name for pc in game.state.private_companies],
+                         [pc.name for pc in cfg.PRIVATE_COMPANIES])
+
+    def test_1846_config(self):
+        cfg = load_config("1846")
+        game = Game.start(["A", "B", "C"], variant="1846")
+        self.assertEqual(game.state.players[0].cash, cfg.starting_cash(3))
+        self.assertEqual([pc.name for pc in game.state.private_companies],
+                         [pc.name for pc in cfg.PRIVATE_COMPANIES])
+
+    def test_1889_config(self):
+        cfg = load_config("1889")
+        game = Game.start(["A", "B", "C", "D", "E"], variant="1889")
+        self.assertEqual(game.state.players[0].cash, cfg.starting_cash(5))
+        self.assertEqual([pc.name for pc in game.state.private_companies],
+                         [pc.name for pc in cfg.PRIVATE_COMPANIES])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/unittests/scenarios/SimulateBuyPrivateCompaniesTests.py
+++ b/app/unittests/scenarios/SimulateBuyPrivateCompaniesTests.py
@@ -58,7 +58,7 @@ class SimulateFullPrivateCompanyRound(unittest.TestCase):
             "Rafael"
         ]
 
-        game = Game.start(player_details)
+        game = Game.start(player_details, variant="1830")
         game.setPlayerOrder()
         game.setCurrentPlayer()
 


### PR DESCRIPTION
## Summary
- add configuration modules for 1830, 1846 and 1889
- adjust Game.start() to load configuration by variant name
- keep example and tests using explicit variant
- add unit tests covering variant configuration

## Testing
- `for f in app/unittests/*.py; do PYTHONPATH=. python3 "$f" || break; done`
- `PYTHONPATH=. python3 app/unittests/GameVariantLoadingTests.py`
