### PR TITLE
Add token and track metadata to configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,16 @@ the actual physical actions (computing best paths, keeping tabs on other players
 This is a quiet experiment with implementing the rules as a daemon in Python. 
 With some effort, I assume different front-ends will be able to hook into the Daemon, giving us much more flexibility
 when creating front ends for the game.
+
+## Configuration Modules
+
+Each game variant under `app/config/` exposes a configuration module. In
+addition to the lists of private and public companies, the modules now provide:
+
+* `TOKEN_COUNTS` – mapping of public company IDs to their starting token supply.
+  Each `PublicCompany` instance created from the module also has a
+  `token_count` attribute populated from this mapping.
+* `TRACK_LAYING_COSTS` – the cost in currency for laying track tiles by
+  `Color`.
+* `SPECIAL_HEX_RULES` – a dictionary of hex identifiers to any special rules
+  that may apply when validating moves.

--- a/app/base.py
+++ b/app/base.py
@@ -183,12 +183,15 @@ class PublicCompany:
         self.owners = {}
         self.stocks = {StockPurchaseSource.IPO: 100, StockPurchaseSource.BANK: 0}
         self.stock_status = StockStatus.NORMAL
+        self.token_count: int = 0
 
     @staticmethod
     def initiate(**kwargs):
         x = PublicCompany()
         for k, v in kwargs.items():
             x.__dict__[k] = v
+        if 'token_count' not in kwargs:
+            x.token_count = 0
         return x
 
     def buy(self, player: Player, source: StockPurchaseSource, amount: int):

--- a/app/config/1830.py
+++ b/app/config/1830.py
@@ -1,4 +1,4 @@
-from app.base import PrivateCompany, PublicCompany, Train
+from app.base import PrivateCompany, PublicCompany, Train, Color
 
 
 def starting_cash(num_players: int) -> int:
@@ -14,9 +14,24 @@ PRIVATE_COMPANIES = [
     PrivateCompany.initiate(6, "Baltimore & Ohio Railroad", "B&O", 220, 30, "I13/I15"),
 ]
 
+TOKEN_COUNTS = {
+    "B&O": 4,
+    "C&O": 3,
+}
+
+TRACK_LAYING_COSTS = {
+    Color.YELLOW: 0,
+    Color.BROWN: 100,
+    Color.RED: 200,
+}
+
+SPECIAL_HEX_RULES = {
+    "G15": "SVR base hex",
+}
+
 PUBLIC_COMPANIES = [
-    PublicCompany.initiate(id="B&O", name="Baltimore & Ohio Railroad", short_name="B&O"),
-    PublicCompany.initiate(id="C&O", name="Chesapeake & Ohio Railway", short_name="C&O"),
+    PublicCompany.initiate(id="B&O", name="Baltimore & Ohio Railroad", short_name="B&O", token_count=TOKEN_COUNTS["B&O"]),
+    PublicCompany.initiate(id="C&O", name="Chesapeake & Ohio Railway", short_name="C&O", token_count=TOKEN_COUNTS["C&O"]),
 ]
 
 # Placeholder data for future rules

--- a/app/config/1846.py
+++ b/app/config/1846.py
@@ -1,4 +1,4 @@
-from app.base import PrivateCompany, PublicCompany, Train
+from app.base import PrivateCompany, PublicCompany, Train, Color
 
 
 def starting_cash(num_players: int) -> int:
@@ -12,9 +12,24 @@ PRIVATE_COMPANIES = [
     PrivateCompany.initiate(4, "Lake Shore Line", "LSL", 200, 20, "D4"),
 ]
 
+TOKEN_COUNTS = {
+    "NYC": 5,
+    "GT": 4,
+}
+
+TRACK_LAYING_COSTS = {
+    Color.YELLOW: 0,
+    Color.BROWN: 100,
+    Color.RED: 200,
+}
+
+SPECIAL_HEX_RULES = {
+    "A1": "Mail Contract base",
+}
+
 PUBLIC_COMPANIES = [
-    PublicCompany.initiate(id="NYC", name="New York Central", short_name="NYC"),
-    PublicCompany.initiate(id="GT", name="Grand Trunk", short_name="GT"),
+    PublicCompany.initiate(id="NYC", name="New York Central", short_name="NYC", token_count=TOKEN_COUNTS["NYC"]),
+    PublicCompany.initiate(id="GT", name="Grand Trunk", short_name="GT", token_count=TOKEN_COUNTS["GT"]),
 ]
 
 # Placeholder data for future rules

--- a/app/config/1889.py
+++ b/app/config/1889.py
@@ -1,4 +1,4 @@
-from app.base import PrivateCompany, PublicCompany, Train
+from app.base import PrivateCompany, PublicCompany, Train, Color
 
 
 def starting_cash(num_players: int) -> int:
@@ -13,9 +13,24 @@ PRIVATE_COMPANIES = [
     PrivateCompany.initiate(5, "Hokkaido Coal", "HC", 200, 25, "Z5"),
 ]
 
+TOKEN_COUNTS = {
+    "SR": 4,
+    "UR": 3,
+}
+
+TRACK_LAYING_COSTS = {
+    Color.YELLOW: 0,
+    Color.BROWN: 100,
+    Color.RED: 200,
+}
+
+SPECIAL_HEX_RULES = {
+    "Z1": "SR home hex",
+}
+
 PUBLIC_COMPANIES = [
-    PublicCompany.initiate(id="SR", name="Sanyo Railway", short_name="SR"),
-    PublicCompany.initiate(id="UR", name="Ueda Railway", short_name="UR"),
+    PublicCompany.initiate(id="SR", name="Sanyo Railway", short_name="SR", token_count=TOKEN_COUNTS["SR"]),
+    PublicCompany.initiate(id="UR", name="Ueda Railway", short_name="UR", token_count=TOKEN_COUNTS["UR"]),
 ]
 
 STOCK_MARKET = []

--- a/app/unittests/GameVariantLoadingTests.py
+++ b/app/unittests/GameVariantLoadingTests.py
@@ -13,6 +13,10 @@ class GameVariantLoadingTests(unittest.TestCase):
                          [pc.name for pc in cfg.PRIVATE_COMPANIES])
         self.assertEqual([pc.name for pc in game.state.public_companies],
                          [pc.name for pc in cfg.PUBLIC_COMPANIES])
+        self.assertEqual([pc.token_count for pc in game.state.public_companies],
+                         [pc.token_count for pc in cfg.PUBLIC_COMPANIES])
+        self.assertTrue(hasattr(cfg, "TRACK_LAYING_COSTS"))
+        self.assertTrue(hasattr(cfg, "SPECIAL_HEX_RULES"))
 
     def test_1846_config(self):
         cfg = load_config("1846")
@@ -22,6 +26,10 @@ class GameVariantLoadingTests(unittest.TestCase):
                          [pc.name for pc in cfg.PRIVATE_COMPANIES])
         self.assertEqual([pc.name for pc in game.state.public_companies],
                          [pc.name for pc in cfg.PUBLIC_COMPANIES])
+        self.assertEqual([pc.token_count for pc in game.state.public_companies],
+                         [pc.token_count for pc in cfg.PUBLIC_COMPANIES])
+        self.assertTrue(hasattr(cfg, "TRACK_LAYING_COSTS"))
+        self.assertTrue(hasattr(cfg, "SPECIAL_HEX_RULES"))
 
     def test_1889_config(self):
         cfg = load_config("1889")
@@ -31,6 +39,10 @@ class GameVariantLoadingTests(unittest.TestCase):
                          [pc.name for pc in cfg.PRIVATE_COMPANIES])
         self.assertEqual([pc.name for pc in game.state.public_companies],
                          [pc.name for pc in cfg.PUBLIC_COMPANIES])
+        self.assertEqual([pc.token_count for pc in game.state.public_companies],
+                         [pc.token_count for pc in cfg.PUBLIC_COMPANIES])
+        self.assertTrue(hasattr(cfg, "TRACK_LAYING_COSTS"))
+        self.assertTrue(hasattr(cfg, "SPECIAL_HEX_RULES"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- capture starting token counts and track building costs for every variant
- store token count on `PublicCompany`
- expose the new constants via config modules
- document config metadata
- test that game variants expose these new fields

## Testing
- `python -m unittest discover -s app/unittests -p '*Tests.py' -v` *(fails: SimulateBuyPrivateCompaniesTests)*
- `python -m unittest app.unittests.GameVariantLoadingTests -v`