### PR TITLE
Implement rusted train bankruptcy flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ the actual physical actions (computing best paths, keeping tabs on other players
 This is a quiet experiment with implementing the rules as a daemon in Python. 
 With some effort, I assume different front-ends will be able to hook into the Daemon, giving us much more flexibility
 when creating front ends for the game.
+
+Recent updates include initial handling of bankrupt companies when trains rust.
+Public companies now track placed station tokens and expose a ``hasValidRoute``
+helper used during operating rounds to determine whether a company can continue
+operating once its trains are gone.


### PR DESCRIPTION
## Summary
- add tokens list to `PublicCompany` and store placed tokens on both board and company
- extend `hasValidRoute` to check for placed stations and trains
- retain board reference in `OperatingRound` so rusted-train checks can use it
- update README with bankruptcy and route notes

## Testing
- `python -m unittest app.unittests.OperatingRoundMinigameTests -v`
- `python -m unittest app.unittests.PrivateCompanyMinigameTests app.unittests.StockRoundMinigameTests app.unittests.BiddingForPrivateCompanyMinigameTests app.unittests.SellPrivateCompanyAuctionTests app.unittests.OperatingRoundMinigameTests app.unittests.GameStateTransitionTests app.unittests.GameVariantLoadingTests -v`
