### PR TITLE
Clarify token tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Public companies now track how many station tokens they have left using a
 in the company configuration. When a token is purchased during an operating
 round its cost is deducted from the company's cash and the available count is
 reduced.
+The total number of tokens a company begins with is stored in the
+`token_count` attribute. At the start of a game `tokens_available` will equal
+`token_count`. Purchasing station tokens decreases `tokens_available` but does
+not change `token_count`.
 
 ## Changelog
 

--- a/app/base.py
+++ b/app/base.py
@@ -182,8 +182,7 @@ class PublicCompany:
         self.name: str = None
         self.short_name: str = None
         self.tokens_available: int = 0
-        self.
-        s: List[int] = []
+        self.token_costs: List[int] = []
         self.president: Player = None
         self.stockPrice = {StockPurchaseSource.IPO: 0, StockPurchaseSource.BANK: 0}
         self.owners = {}
@@ -200,10 +199,10 @@ class PublicCompany:
             x.__dict__[k] = v
         if 'token_costs' not in kwargs:
             x.token_costs = []
-        if 'tokens_available' not in kwargs:
-            x.tokens_available = len(x.token_costs)
         if 'token_count' not in kwargs:
-            x.token_count = len(x.token_costs
+            x.token_count = len(x.token_costs)
+        if 'tokens_available' not in kwargs:
+            x.tokens_available = x.token_count
         return x
 
     def buy(self, player: Player, source: StockPurchaseSource, amount: int):

--- a/app/unittests/GameVariantLoadingTests.py
+++ b/app/unittests/GameVariantLoadingTests.py
@@ -15,6 +15,8 @@ class GameVariantLoadingTests(unittest.TestCase):
                          [pc.name for pc in cfg.PUBLIC_COMPANIES])
         self.assertEqual([pc.token_count for pc in game.state.public_companies],
                          [pc.token_count for pc in cfg.PUBLIC_COMPANIES])
+        self.assertEqual([pc.tokens_available for pc in game.state.public_companies],
+                         [pc.token_count for pc in cfg.PUBLIC_COMPANIES])
         self.assertTrue(hasattr(cfg, "TRACK_LAYING_COSTS"))
         self.assertTrue(hasattr(cfg, "SPECIAL_HEX_RULES"))
 
@@ -28,6 +30,8 @@ class GameVariantLoadingTests(unittest.TestCase):
                          [pc.name for pc in cfg.PUBLIC_COMPANIES])
         self.assertEqual([pc.token_count for pc in game.state.public_companies],
                          [pc.token_count for pc in cfg.PUBLIC_COMPANIES])
+        self.assertEqual([pc.tokens_available for pc in game.state.public_companies],
+                         [pc.token_count for pc in cfg.PUBLIC_COMPANIES])
         self.assertTrue(hasattr(cfg, "TRACK_LAYING_COSTS"))
         self.assertTrue(hasattr(cfg, "SPECIAL_HEX_RULES"))
 
@@ -40,6 +44,8 @@ class GameVariantLoadingTests(unittest.TestCase):
         self.assertEqual([pc.name for pc in game.state.public_companies],
                          [pc.name for pc in cfg.PUBLIC_COMPANIES])
         self.assertEqual([pc.token_count for pc in game.state.public_companies],
+                         [pc.token_count for pc in cfg.PUBLIC_COMPANIES])
+        self.assertEqual([pc.tokens_available for pc in game.state.public_companies],
                          [pc.token_count for pc in cfg.PUBLIC_COMPANIES])
         self.assertTrue(hasattr(cfg, "TRACK_LAYING_COSTS"))
         self.assertTrue(hasattr(cfg, "SPECIAL_HEX_RULES"))

--- a/app/unittests/OperatingRoundMinigameTests.py
+++ b/app/unittests/OperatingRoundMinigameTests.py
@@ -85,6 +85,7 @@ class OperatingRoundTokenTests(unittest.TestCase):
         self.assertEqual(self.company.cash, 1000-40)
         self.assertEqual(self.company.tokens_available, 3)
         self.assertIn(move.token, self.board.tokens["A1"])
+        self.assertEqual(self.company.token_count, 4)
 
     def test_second_token_cost(self):
         # place first token
@@ -106,6 +107,7 @@ class OperatingRoundTokenTests(unittest.TestCase):
         self.assertTrue(oround.run(move2, self.state, board=self.board))
         self.assertEqual(self.company.cash, 1000 - 40 - 60)
         self.assertEqual(self.company.tokens_available, 2)
+        self.assertEqual(self.company.token_count, 4)
 
     def test_invalid_token_no_track(self):
         move = OperatingRoundMove()


### PR DESCRIPTION
## Summary
- clarify how `tokens_available` and `token_count` work in the README
- track token totals separately from available count
- verify token counts in variant loading tests
- ensure token count doesn't change when buying tokens

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*