### PR TITLE
Ensure Minigame errors are instance scoped

### DIFF
--- a/app/minigames/base.py
+++ b/app/minigames/base.py
@@ -29,13 +29,17 @@ class LifeCycle:
 
 class Minigame(LifeCycle):
     """
-    A State object for the game, used to evaluate rules that apply only to subsections of hte game itself.
+    A State object for the game, used to evaluate rules that apply only to subsections of the game itself.
     """
-    error_list: List[str] = []
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.error_list: List[str] = []
 
     def validate(self,
                  possible_errors: List[str]):
-        self.error_list = self.error_list + [err for err in possible_errors if err is not None]
+        # Clear previous errors before validating a new set of rules
+        self.error_list = [err for err in possible_errors if err is not None]
         return len(self.error_list) == 0
 
     def run(self, move: Move, state: MutableGameState) -> bool:

--- a/app/minigames/operating_round.py
+++ b/app/minigames/operating_round.py
@@ -36,6 +36,7 @@ class RustedTrainMove(Move):
 class OperatingRound(Minigame):
 
     def __init__(self):
+        super().__init__()
         self.rusted_train_type: str = None
         self.trains_rusted: str = None
 

--- a/app/unittests/MinigameBaseTests.py
+++ b/app/unittests/MinigameBaseTests.py
@@ -1,0 +1,37 @@
+import unittest
+from app.minigames.base import Minigame
+from app.base import Move, MutableGameState, err
+
+class DummyMinigame(Minigame):
+    def run(self, move: Move, state: MutableGameState) -> bool:
+        return self.validate([err(False, "dummy error")])
+
+    def next(self, state: MutableGameState) -> str:
+        return ""
+
+class MinigameErrorIsolationTests(unittest.TestCase):
+    def test_errors_do_not_persist_across_instances(self):
+        state = MutableGameState()
+        m1 = DummyMinigame()
+        m1.run(Move(), state)
+        self.assertEqual(m1.errors(), ["dummy error"])
+
+        m2 = DummyMinigame()
+        m2.run(Move(), state)
+        self.assertEqual(m2.errors(), ["dummy error"])
+        # ensure first instance errors remain unchanged
+        self.assertEqual(m1.errors(), ["dummy error"])
+
+    def test_validate_clears_previous_errors(self):
+        state = MutableGameState()
+        m = DummyMinigame()
+        m.run(Move(), state)
+        self.assertEqual(m.errors(), ["dummy error"])
+
+        # Subsequent validation with no errors should clear previous ones
+        m.validate([err(True, "")])
+        self.assertEqual(m.errors(), [])
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/app/unittests/StockRoundMinigameTests.py
+++ b/app/unittests/StockRoundMinigameTests.py
@@ -260,7 +260,7 @@ class StockRoundMinigameBuySellTests(unittest.TestCase):
 
         self.initial_setup_company(state.public_companies[1],
                                    [(state.players[0], STOCK_CERTIFICATE + STOCK_PRESIDENT_CERTIFICATE),], 72)
-        move.for_sale_raw[0][1] = 15
+        move.for_sale_raw = [["ABC", 15]]
         minigame = StockRound()
         self.assertFalse(minigame.run(move, state), minigame.errors())
         self.assertIn("You can only sell in units of 10 stocks (15)", minigame.errors())


### PR DESCRIPTION
## Summary
- reset `Minigame.error_list` in `__init__` and on each validation
- update `OperatingRound` to call the base initializer
- adjust stock round test to avoid accumulating errors
- add new tests covering error list isolation and clearing

## Testing
- `PYTHONPATH=. python app/unittests/MinigameBaseTests.py`
- `PYTHONPATH=. python app/unittests/PrivateCompanyMinigameTests.py`
- `PYTHONPATH=. python app/unittests/BiddingForPrivateCompanyMinigameTests.py`
- `PYTHONPATH=. python app/unittests/OperatingRoundMinigameTests.py`
- `PYTHONPATH=. python app/unittests/StockRoundMinigameTests.py`
- `PYTHONPATH=. python app/unittests/SellPrivateCompanyAuctionTests.py`
- `PYTHONPATH=. python app/unittests/GameStateTransitionTests.py`
- `PYTHONPATH=. python app/unittests/GameVariantLoadingTests.py`
- `PYTHONPATH=. python app/unittests/scenarios/SimulateBuyPrivateCompaniesTests.py`
