### PR TITLE
Handle operating round increment

### DIFF
--- a/app/minigames/operating_round.py
+++ b/app/minigames/operating_round.py
@@ -221,9 +221,10 @@ class OperatingRound(Minigame):
         # Do we have another operating round?
         if not kwargs.get("playerTurn").anotherCompanyWaiting() and \
                         kwargs.get("currentOperatingRound") < kwargs.get("totalOperatingRounds"):
-            # TODO increment current operating round
-            kwargs.get("playerTurn").restart() # Should re-calculate the turn order and run a new operating round from the start.
-            return "OperatingRound{}".format(kwargs.get("currentOperatingRound") + 1)
+            current_or = kwargs.get("currentOperatingRound") + 1
+            kwargs["currentOperatingRound"] = current_or
+            kwargs.get("playerTurn").restart(current_or)  # Recalculate order for new OR
+            return "OperatingRound{}".format(current_or)
 
         return "StockRound"
 

--- a/app/unittests/OperatingRoundMinigameTests.py
+++ b/app/unittests/OperatingRoundMinigameTests.py
@@ -30,10 +30,11 @@ def fake_company(name="1", cash=1000):
 class PlayerTurnStub:
     def __init__(self, waiting=True):
         self.waiting = waiting
+        self.restart_called_with = None
     def anotherCompanyWaiting(self):
         return self.waiting
-    def restart(self):
-        pass
+    def restart(self, current_or=None):
+        self.restart_called_with = current_or
 
 
 class OperatingRoundTrackTests(unittest.TestCase):
@@ -212,6 +213,18 @@ class OperatingRoundNextTests(unittest.TestCase):
         self.assertEqual(oround.next(**state), "OperatingRound2")
         state["currentOperatingRound"] = 2
         self.assertEqual(oround.next(**state), "StockRound")
+
+    def test_round_increment_restart(self):
+        oround = OperatingRound()
+        state = {
+            "public_companies": [],
+            "playerTurn": PlayerTurnStub(False),
+            "currentOperatingRound": 1,
+            "totalOperatingRounds": 3,
+        }
+        nxt = oround.next(**state)
+        self.assertEqual(nxt, "OperatingRound2")
+        self.assertEqual(state["playerTurn"].restart_called_with, 2)
 
 
 class TrainsRustedFlowTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- increment current operating round and pass new round number to `playerTurn.restart`
- track `restart` calls in `PlayerTurnStub`
- test that the operating round advances and restart is called with the right value

## Testing
- `python -m py_compile app/minigames/operating_round.py app/unittests/OperatingRoundMinigameTests.py`
- `python -m pytest -q` *(fails: No module named pytest)*