### PR TITLE
Add docs for stock rounds and private company auctions

### DIFF
--- a/app/minigames/PrivateCompanyStockRoundAuction/README.md
+++ b/app/minigames/PrivateCompanyStockRoundAuction/README.md
@@ -1,14 +1,37 @@
 Private Company Auction During Stock Round
 ------------------------------------------
 
+Players may offer one of their private companies for sale instead of buying a
+share.  Each other player, in turn order, may bid or pass on the company.
+When all have responded, the owner chooses whether to accept the highest bid.
+If no bid is accepted the company remains with its original owner.  This
+procedure follows rule `7.1`.
+
 Technical Explanation
 ---------------------
+
+The `PrivateCompanyStockRoundAuction` minigame has two phases.  `Auction`
+collects bids from the other players and stores them on the game state.  Once
+everyone has acted, `AuctionDecision` lets the selling player accept a bid or
+reject them all.  Cash is exchanged and the private's ownership updated if a
+bid is accepted.
 
 Auction
 -------
 
+Handles the bidding step.  Bids must be between half and twice the printed
+value of the company.  A player may also pass.  When all opponents have either
+bid or passed the minigame proceeds to `AuctionDecision`.
+
 AuctionDecision
 ---------------
 
+The owner reviews the offers and either accepts one or rejects them all.  If a
+bid is accepted the funds transfer immediately and play returns to the stock
+round.
+
 Transition to Stock Round
-------------------------- 
+-------------------------
+
+After `AuctionDecision` resolves, control returns to `StockRound` so the next
+player may act.

--- a/app/minigames/StockRound/README.md
+++ b/app/minigames/StockRound/README.md
@@ -1,14 +1,39 @@
 Stock Round
 -----------
 
+The stock round is when players buy and sell certificates of the public
+companies.  On your turn you may first sell any number of shares that the
+rules allow and then optionally purchase a single certificate.  No sales are
+permitted in the first stock round.
+
+When you sell shares, the company's marker moves one space down on the stock
+market for each 10% sold.  If all of a company's stock is in players' hands,
+its price moves one space up.  These movements follow the stock market rules
+in sections `10.0`–`16.0` of the rulebook.
+
+### Priority Deal
+
+Whoever is seated to the left of the last player to successfully buy a
+certificate receives Priority Deal for the next stock round.  Players who pass
+are skipped until the round ends, but Priority Deal keeps the order for the
+following stock round.
+
 Technical Explanation
 ---------------------
+
+The `StockRound` minigame processes `StockRoundMove` objects.  It validates
+purchases, sales and passes, updates company presidents and tracks how many
+shares have changed hands in the current round.
 
 BuyPrivateCompany
 -----------------
 
+A player may choose to auction one of their private companies instead of
+buying a share.  This invokes the `PrivateCompanyStockRoundAuction`
+minigame.  The auction process is described in rule `7.1`.
+
 Transition to Operating Round
 -----------------------------
- 
-  
-  
+
+Once every player consecutively passes, the game moves to the next operating
+round.


### PR DESCRIPTION
## Summary
- document the flow of a Stock Round
- explain priority deal and stock price movements
- describe how private companies are auctioned during a stock round

## Testing
- `pytest -q` *(fails: command not found)*