### PR TITLE
Add track upgrade costs and sequential placement rules

### DIFF
--- a/app/minigames/README.md
+++ b/app/minigames/README.md
@@ -1,0 +1,11 @@
+Operating Round
+---------------
+
+During an operating round each public company may lay or upgrade a single track tile.
+The cost of laying track depends on the tile colour and is defined by the active
+configuration module via `TRACK_LAYING_COSTS`.
+
+Track must be upgraded one step at a time following the colour progression
+(Yellow → Brown → Red → Gray). A company may not skip directly from a yellow
+ tile to a red tile, for example. The appropriate cost is deducted from the
+company's cash whenever a tile is placed.

--- a/app/minigames/operating_round.py
+++ b/app/minigames/operating_round.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Any
 
 from app.base import PrivateCompany, Move, GameBoard, Track, Token, Route, PublicCompany, Train, Color, MutableGameState, err
 from app.minigames.base import Minigame
@@ -22,6 +22,7 @@ class OperatingRoundMove(Move):
         self.token: Token = None
         self.track: Track = None
         self.train: Train = None
+        self.config = None
 
     pass
 
@@ -43,6 +44,7 @@ class OperatingRound(Minigame):
     def run(self, move: OperatingRoundMove, game_state: MutableGameState, **extra) -> bool:
         move.backfill(game_state)
         move.board = extra.get("board")
+        move.config = extra.get("config")
         # Store board for later checks during ``next``
         self.board = move.board
 
@@ -64,9 +66,14 @@ class OperatingRound(Minigame):
     def constructTrack(self, move: OperatingRoundMove, **kwargs):
         track: Track = move.track
         board: GameBoard = kwargs.get("board")
+        config = kwargs.get("config")
         if move.construct_track and self.isValidTrackPlacement(move):
             board.setTrack(track)
-            move.public_company.cash -= 0  # yellow tiles free in 1830
+            if config is not None:
+                cost = config.TRACK_LAYING_COSTS.get(track.color, 0)
+            else:
+                cost = 0
+            move.public_company.cash -= cost
 
     def purchaseToken(self, move: OperatingRoundMove, **kwargs):
         token: Token = move.token
@@ -198,14 +205,10 @@ class OperatingRound(Minigame):
 
         validations = [
             err(track.location is not None, "Your track needs to be on a location that exists"),
-            err(existing is None or color_order[track.color] > color_order.get(existing.color, 0),
-                "Someone has already set a tile there"),
+            err(existing is None or color_order[track.color] == color_order.get(existing.color, 0) + 1,
+                "Track upgrades must follow the colour progression"),
             err(existing is not None or has_company_token,
                 "You cannot access that tile from your company"),
-            err(existing is None or track.color != Color.BROWN or color_order.get(existing.color, 0) >= color_order[Color.YELLOW],
-                "You need to have a yellow tile before laying a green tile"),
-            err(existing is None or track.color != Color.RED or color_order.get(existing.color, 0) >= color_order[Color.BROWN],
-                "You need to have a green tile before laying an orange tile"),
         ]
 
         return self.validate(validations)

--- a/app/unittests/OperatingRoundMinigameTests.py
+++ b/app/unittests/OperatingRoundMinigameTests.py
@@ -75,6 +75,49 @@ class OperatingRoundTrackTests(unittest.TestCase):
         oround = OperatingRound()
         self.assertFalse(oround.run(move, self.state, board=self.board))
 
+    def test_track_upgrade_cost_deducted(self):
+        from app.config import load_config
+        cfg = load_config("1830")
+        self.board.setToken(Token(self.company, "A1", 0))
+
+        first = OperatingRoundMove()
+        first.player_id = "A"
+        first.construct_track = True
+        first.track = Track("1", "1", Color.YELLOW, "A1", 0)
+        first.public_company = self.company
+        oround = OperatingRound()
+        self.assertTrue(oround.run(first, self.state, board=self.board, config=cfg))
+
+        start_cash = self.company.cash
+
+        upgrade = OperatingRoundMove()
+        upgrade.player_id = "A"
+        upgrade.construct_track = True
+        upgrade.track = Track("2", "2", Color.BROWN, "A1", 0)
+        upgrade.public_company = self.company
+        self.assertTrue(oround.run(upgrade, self.state, board=self.board, config=cfg))
+        self.assertEqual(self.company.cash, start_cash - cfg.TRACK_LAYING_COSTS[Color.BROWN])
+
+    def test_skip_track_color_invalid(self):
+        from app.config import load_config
+        cfg = load_config("1830")
+        self.board.setToken(Token(self.company, "A1", 0))
+
+        first = OperatingRoundMove()
+        first.player_id = "A"
+        first.construct_track = True
+        first.track = Track("1", "1", Color.YELLOW, "A1", 0)
+        first.public_company = self.company
+        oround = OperatingRound()
+        self.assertTrue(oround.run(first, self.state, board=self.board, config=cfg))
+
+        upgrade = OperatingRoundMove()
+        upgrade.player_id = "A"
+        upgrade.construct_track = True
+        upgrade.track = Track("2", "2", Color.RED, "A1", 0)
+        upgrade.public_company = self.company
+        self.assertFalse(oround.run(upgrade, self.state, board=self.board, config=cfg))
+
 
 class OperatingRoundTokenTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- deduct track laying costs using config values
- prevent skipping tile colors when upgrading track
- add tests for new track rules
- document operating round track rules

## Testing
- `python -m unittest app.unittests.OperatingRoundMinigameTests -v`