### PR TITLE
Enforce single tile lay per Operating Round

### DIFF
--- a/app/base.py
+++ b/app/base.py
@@ -33,6 +33,9 @@ class MutableGameState:
         self.stock_round_play:int = 0
         self.stock_round_count: int = 0
         self.players: List[Player] = None
+        # Track which public companies have laid track during the current
+        # operating round. Keys are company ids.
+        self.track_laid: Set[str] = set()
 
     pass
 

--- a/app/unittests/OperatingRoundMinigameTests.py
+++ b/app/unittests/OperatingRoundMinigameTests.py
@@ -75,6 +75,43 @@ class OperatingRoundTrackTests(unittest.TestCase):
         oround = OperatingRound()
         self.assertFalse(oround.run(move, self.state, board=self.board))
 
+    def test_only_one_tile_per_round(self):
+        self.board.setToken(Token(self.company, "A1", 0))
+        move1 = OperatingRoundMove()
+        move1.player_id = "A"
+        move1.construct_track = True
+        move1.track = Track("1", "1", Color.YELLOW, "A1", 0)
+        move1.public_company = self.company
+        oround = OperatingRound()
+        self.assertTrue(oround.run(move1, self.state, board=self.board))
+
+        move2 = OperatingRoundMove()
+        move2.player_id = "A"
+        move2.construct_track = True
+        move2.track = Track("2", "2", Color.YELLOW, "A2", 0)
+        move2.public_company = self.company
+        self.assertFalse(oround.run(move2, self.state, board=self.board))
+
+    def test_track_flag_resets_on_start(self):
+        self.board.setToken(Token(self.company, "A1", 0))
+        move1 = OperatingRoundMove()
+        move1.player_id = "A"
+        move1.construct_track = True
+        move1.track = Track("1", "1", Color.YELLOW, "A1", 0)
+        move1.public_company = self.company
+        oround = OperatingRound()
+        self.assertTrue(oround.run(move1, self.state, board=self.board))
+
+        OperatingRound.onStart(self.state)
+
+        move2 = OperatingRoundMove()
+        move2.player_id = "A"
+        move2.construct_track = True
+        move2.track = Track("2", "2", Color.YELLOW, "A2", 0)
+        move2.public_company = self.company
+        self.board.setToken(Token(self.company, "A2", 0))
+        self.assertTrue(oround.run(move2, self.state, board=self.board))
+
 
 class OperatingRoundTokenTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- track which corporation lays track during an operating round
- block additional track builds after a tile is laid
- reset track placement flag when a new operating round begins
- test one-tile restriction

## Testing
- `python -m unittest discover -s app/unittests -p "*Tests.py"`