### PR TITLE
Enforce one token per operating round

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ reduced.
 The total number of tokens a company begins with is stored in the
 `token_count` attribute. At the start of a game `tokens_available` will equal
 `token_count`. Purchasing station tokens decreases `tokens_available` but does
-not change `token_count`.
+not change `token_count`. Each company also tracks whether it has already placed
+a station token in the current operating round and the engine enforces the rule
+that at most one token may be placed per round.
 
 ## Changelog
 
@@ -40,4 +42,6 @@ Recent updates include initial handling of bankrupt companies when trains rust.
 Public companies now track placed station tokens and expose a ``hasValidRoute``
 helper used during operating rounds to determine whether a company can continue
 operating once its trains are gone.
+Token placement is now limited to one per operating round and the flag resets at
+the start of each round.
 

--- a/app/base.py
+++ b/app/base.py
@@ -191,6 +191,7 @@ class PublicCompany:
         self.bankrupt = False
         self.tokens: List[Token] = []
         self.token_count: int = 0
+        self.token_placed: bool = False
 
     @staticmethod
     def initiate(**kwargs):
@@ -203,6 +204,7 @@ class PublicCompany:
             x.token_count = len(x.token_costs)
         if 'tokens_available' not in kwargs:
             x.tokens_available = x.token_count
+        x.token_placed = False
         return x
 
     def buy(self, player: Player, source: StockPurchaseSource, amount: int):

--- a/app/minigames/operating_round.py
+++ b/app/minigames/operating_round.py
@@ -77,6 +77,7 @@ class OperatingRound(Minigame):
             board.setToken(token)
             move.public_company.cash -= cost
             move.public_company.tokens_available -= 1
+            move.public_company.token_placed = True
             move.token = token
 
     def runRoutes(self, move: OperatingRoundMove, **kwargs):
@@ -174,6 +175,7 @@ class OperatingRound(Minigame):
             err(len(same_company) == 0, "You cannot put two tokens for the same company a location"),
             err(token.company.tokens_available > 0, "There are no remaining tokens for that company"),
             err(token.company.cash >= cost, "You don't have enough cash to buy a token"),
+            err(not token.company.token_placed, "You have already placed a token this round"),
         ]
 
         return self.validate(validations)
@@ -243,6 +245,10 @@ class OperatingRound(Minigame):
         private_companies: List[PrivateCompany] = kwargs.get("private_companies")
         for pc in private_companies:
             pc.distributeRevenue()
+
+        # Reset per-round flags on public companies
+        for company in kwargs.get("public_companies", []):
+            company.token_placed = False
 
         # Create a list of floated companies (?)
 

--- a/app/unittests/OperatingRoundMinigameTests.py
+++ b/app/unittests/OperatingRoundMinigameTests.py
@@ -108,6 +108,9 @@ class OperatingRoundTokenTests(unittest.TestCase):
         oround = OperatingRound()
         self.assertTrue(oround.run(move, self.state, board=self.board))
 
+        # new operating round begins
+        OperatingRound.onStart(public_companies=[self.company], private_companies=[])
+
         # prepare second location
         self.board.setTrack(Track("2", "2", Color.YELLOW, "B1", 0))
         move2 = OperatingRoundMove()
@@ -119,6 +122,25 @@ class OperatingRoundTokenTests(unittest.TestCase):
         self.assertEqual(self.company.cash, 1000 - 40 - 60)
         self.assertEqual(self.company.tokens_available, 2)
         self.assertEqual(self.company.token_count, 4)
+
+    def test_invalid_second_token_same_round(self):
+        # place first token
+        move = OperatingRoundMove()
+        move.player_id = "A"
+        move.purchase_token = True
+        move.token = Token(self.company, "A1", 0)
+        move.public_company = self.company
+        oround = OperatingRound()
+        self.assertTrue(oround.run(move, self.state, board=self.board))
+
+        # attempt second token without starting new round
+        self.board.setTrack(Track("2", "2", Color.YELLOW, "B1", 0))
+        move2 = OperatingRoundMove()
+        move2.player_id = "A"
+        move2.purchase_token = True
+        move2.token = Token(self.company, "B1", 0)
+        move2.public_company = self.company
+        self.assertFalse(oround.run(move2, self.state, board=self.board))
 
     def test_invalid_token_no_track(self):
         move = OperatingRoundMove()


### PR DESCRIPTION
## Summary
- track whether a company placed a token this operating round
- reset the token flag at the start of each operating round
- disallow token purchase if a token was already placed
- update tests for new behaviour and add case for multiple tokens in one OR
- document token placement restrictions

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*