### PR TITLE
Implement Priority Deal tracking

### DIFF
--- a/app/base.py
+++ b/app/base.py
@@ -33,6 +33,7 @@ class MutableGameState:
         self.stock_round_play:int = 0
         self.stock_round_count: int = 0
         self.players: List[Player] = None
+        self.priority_deal_player: Player = None
 
     pass
 

--- a/app/minigames/StockRound/minigame_stockround.py
+++ b/app/minigames/StockRound/minigame_stockround.py
@@ -1,5 +1,5 @@
 from functools import reduce
-from typing import List
+from typing import List, Optional
 
 from app.base import PublicCompany, StockPurchaseSource, Player, err, MutableGameState, STOCK_CERTIFICATE, \
     STOCK_PRESIDENT_CERTIFICATE
@@ -11,6 +11,11 @@ from app.minigames.base import Minigame
 
 class StockRound(Minigame):
     """Buy / Sell Public Companies, Private Companies"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.sell_private_company_auction = False
+        self.last_deal_player: Optional[Player] = None
 
     def _buyround(self, move: StockRoundMove, kwargs: MutableGameState) -> None:
         purchase_amount = STOCK_CERTIFICATE
@@ -50,6 +55,7 @@ class StockRound(Minigame):
         self._buyround(move, kwargs)
         self._sellround(move, kwargs)
         kwargs.stock_round_play += 1
+        self.last_deal_player = move.player
         return True
 
     def _buy(self, move: StockRoundMove, kwargs: MutableGameState) -> bool:
@@ -59,6 +65,7 @@ class StockRound(Minigame):
             return False
         self._buyround(move, kwargs)
         kwargs.stock_round_play += 1
+        self.last_deal_player = move.player
         return True
 
     def _sell(self, move: StockRoundMove, kwargs: MutableGameState) -> bool:
@@ -66,6 +73,7 @@ class StockRound(Minigame):
             return False
         self._sellround(move, kwargs)
         kwargs.stock_round_play += 1
+        self.last_deal_player = move.player
         return True
 
     def run(self, move: StockRoundMove, kwargs: MutableGameState) -> bool:
@@ -108,6 +116,9 @@ class StockRound(Minigame):
         if kwargs.stock_round_play % len(players) == 0 \
                 and kwargs.stock_round_play > 0 \
                 and kwargs.stock_round_passed == len(players):
+            if self.last_deal_player:
+                idx = players.index(self.last_deal_player)
+                kwargs.priority_deal_player = players[(idx + 1) % len(players)]
             return "OperatingRound1"
         return "StockRound"
 

--- a/app/state.py
+++ b/app/state.py
@@ -118,6 +118,7 @@ class Game:
         game.config = config
         game.state = MutableGameState()
         game.state.players = players
+        game.state.priority_deal_player = players[0] if players else None
         game.state.private_companies = config.PRIVATE_COMPANIES
         game.state.public_companies = config.PUBLIC_COMPANIES
 
@@ -174,6 +175,12 @@ class Game:
         }
 
         player_order_generator = player_order_functions.get(self.minigame_class)(self.getState())
+
+        if self.minigame_class == "StockRound" and self.state.priority_deal_player in self.state.players:
+            players = self.state.players
+            start = players.index(self.state.priority_deal_player)
+            player_order_generator.players = players[start:] + players[:start]
+            player_order_generator.initial_player = self.state.priority_deal_player
 
         if player_order_generator.stacking_type:
             self.player_order_fn_list.append(player_order_generator)

--- a/app/unittests/PriorityDealTests.py
+++ b/app/unittests/PriorityDealTests.py
@@ -1,0 +1,64 @@
+import json
+import unittest
+
+from app.base import Move, MutableGameState
+from app.minigames.StockRound.move import StockRoundMove
+from app.minigames.StockRound.minigame_stockround import StockRound
+from app.state import Game
+from app.unittests.PrivateCompanyMinigameTests import fake_player
+from app.unittests.StockRoundMinigameTests import fake_public_company
+
+class PriorityDealTests(unittest.TestCase):
+    def setup_state(self):
+        state = MutableGameState()
+        state.players = [fake_player("A"), fake_player("B")]
+        state.public_companies = [fake_public_company("ABC")]
+        state.stock_round_count = 1
+        state.stock_round_play = 0
+        state.stock_round_passed = 0
+        state.sales = [{}, {}]
+        state.purchases = [{}, {}]
+        state.priority_deal_player = state.players[0]
+        return state
+
+    def test_priority_deal_changes_after_purchase(self):
+        state = self.setup_state()
+        # Player A buys one share
+        msg = json.dumps({
+            "player_id": "A",
+            "public_company_id": "ABC",
+            "source": "IPO",
+            "move_type": "BUY",
+            "ipo_price": 90
+        })
+        buy_move = StockRoundMove.fromMove(Move.fromMessage(msg))
+        sr = StockRound()
+        self.assertTrue(sr.run(buy_move, state))
+
+        # Player B passes
+        msg = json.dumps({"player_id": "B", "move_type": "PASS"})
+        pass_move_b = StockRoundMove.fromMove(Move.fromMessage(msg))
+        self.assertTrue(sr.run(pass_move_b, state))
+
+        # Player A passes -> round ends
+        msg = json.dumps({"player_id": "A", "move_type": "PASS"})
+        pass_move_a = StockRoundMove.fromMove(Move.fromMessage(msg))
+        self.assertTrue(sr.run(pass_move_a, state))
+        # force end-of-round conditions
+        state.stock_round_play = len(state.players)
+        state.stock_round_passed = len(state.players)
+        self.assertEqual(sr.next(state), "OperatingRound1")
+        self.assertEqual(state.priority_deal_player, state.players[1])
+
+    def test_set_player_order_uses_priority_deal(self):
+        state = self.setup_state()
+        state.priority_deal_player = state.players[1]
+        game = Game()
+        game.state = state
+        game.minigame_class = "StockRound"
+        game.setPlayerOrder()
+        game.setCurrentPlayer()
+        self.assertEqual(game.current_player, state.players[1])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- track `priority_deal_player` in `MutableGameState`
- initialise priority deal in `Game.initialize`
- rotate player order in stock rounds using priority deal
- update priority deal at end of stock rounds
- add unit tests for priority deal behaviour

## Testing
- `python -m unittest discover -v -s app/unittests -p '*Tests.py'`