### PR TITLE
Add green tile colour

### DIFF
--- a/app/base.py
+++ b/app/base.py
@@ -44,8 +44,9 @@ class MutableGameState:
 class Color(Enum):
     GRAY = 1
     YELLOW = 2
-    BROWN = 3
-    RED = 4
+    GREEN = 3
+    BROWN = 4
+    RED = 5
 
 
 class Train:

--- a/app/config/1830.py
+++ b/app/config/1830.py
@@ -21,6 +21,7 @@ TOKEN_COUNTS = {
 
 TRACK_LAYING_COSTS = {
     Color.YELLOW: 0,
+    Color.GREEN: 0,
     Color.BROWN: 100,
     Color.RED: 200,
 }

--- a/app/config/1846.py
+++ b/app/config/1846.py
@@ -19,6 +19,7 @@ TOKEN_COUNTS = {
 
 TRACK_LAYING_COSTS = {
     Color.YELLOW: 0,
+    Color.GREEN: 0,
     Color.BROWN: 100,
     Color.RED: 200,
 }

--- a/app/config/1889.py
+++ b/app/config/1889.py
@@ -20,6 +20,7 @@ TOKEN_COUNTS = {
 
 TRACK_LAYING_COSTS = {
     Color.YELLOW: 0,
+    Color.GREEN: 0,
     Color.BROWN: 100,
     Color.RED: 200,
 }

--- a/app/minigames/README.md
+++ b/app/minigames/README.md
@@ -6,6 +6,6 @@ The cost of laying track depends on the tile colour and is defined by the active
 configuration module via `TRACK_LAYING_COSTS`.
 
 Track must be upgraded one step at a time following the colour progression
-(Yellow → Brown → Red → Gray). A company may not skip directly from a yellow
+(Yellow → Green → Brown → Red → Gray). A company may not skip directly from a yellow
  tile to a red tile, for example. The appropriate cost is deducted from the
 company's cash whenever a tile is placed.

--- a/app/minigames/operating_round.py
+++ b/app/minigames/operating_round.py
@@ -203,9 +203,10 @@ class OperatingRound(Minigame):
 
         color_order = {
             Color.YELLOW: 1,
-            Color.BROWN: 2,
-            Color.RED: 3,
-            Color.GRAY: 4
+            Color.GREEN: 2,
+            Color.BROWN: 3,
+            Color.RED: 4,
+            Color.GRAY: 5
         }
 
         has_company_token = any(

--- a/app/unittests/OperatingRoundMinigameTests.py
+++ b/app/unittests/OperatingRoundMinigameTests.py
@@ -125,12 +125,19 @@ class OperatingRoundTrackTests(unittest.TestCase):
         oround = OperatingRound()
         self.assertTrue(oround.run(first, self.state, board=self.board, config=cfg))
 
+        green = OperatingRoundMove()
+        green.player_id = "A"
+        green.construct_track = True
+        green.track = Track("2", "2", Color.GREEN, "A1", 0)
+        green.public_company = self.company
+        self.assertTrue(oround.run(green, self.state, board=self.board, config=cfg))
+
         start_cash = self.company.cash
 
         upgrade = OperatingRoundMove()
         upgrade.player_id = "A"
         upgrade.construct_track = True
-        upgrade.track = Track("2", "2", Color.BROWN, "A1", 0)
+        upgrade.track = Track("3", "3", Color.BROWN, "A1", 0)
         upgrade.public_company = self.company
         self.assertTrue(oround.run(upgrade, self.state, board=self.board, config=cfg))
         self.assertEqual(self.company.cash, start_cash - cfg.TRACK_LAYING_COSTS[Color.BROWN])
@@ -151,7 +158,7 @@ class OperatingRoundTrackTests(unittest.TestCase):
         upgrade = OperatingRoundMove()
         upgrade.player_id = "A"
         upgrade.construct_track = True
-        upgrade.track = Track("2", "2", Color.RED, "A1", 0)
+        upgrade.track = Track("2", "2", Color.BROWN, "A1", 0)
         upgrade.public_company = self.company
         self.assertFalse(oround.run(upgrade, self.state, board=self.board, config=cfg))
 


### PR DESCRIPTION
## Summary
- expand tile colours with `GREEN`
- validate track progression yellow→green→brown→red→gray
- update per-game configs
- document updated colour order
- adjust operating round tests

## Testing
- `pytest -q` *(fails: command not found)*