### PR TITLE
Enforce pay_dividend default and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ that at most one token may be placed per round.
 
 Operating round moves must explicitly state whether dividends will be paid with
 the `pay_dividend` flag. This value must be `True` or `False` and a company can
-only choose once it has calculated income by running routes. When dividends are
-distributed that income is removed from the company and credited directly to the
-players according to their share percentage.
+only choose once it has calculated income by running routes. When creating an
+`OperatingRoundMove` the flag defaults to `False` so tests and simple
+integrations may omit it. When dividends are distributed that income is removed
+from the company and credited directly to the players according to their share
+percentage.
 
 ## Changelog
 
@@ -52,4 +54,9 @@ helper used during operating rounds to determine whether a company can continue
 operating once its trains are gone.
 Token placement is now limited to one per operating round and the flag resets at
 the start of each round.
+
+Routes are now checked against the capacity of the trains assigned to a company.
+Each list of stops must form a continuous path across existing track tiles and
+cannot exceed the length of any available train. Invalid routes are rejected
+during the operating round.
 

--- a/app/minigames/README.md
+++ b/app/minigames/README.md
@@ -9,3 +9,7 @@ Track must be upgraded one step at a time following the colour progression
 (Yellow → Brown → Red → Gray). A company may not skip directly from a yellow
  tile to a red tile, for example. The appropriate cost is deducted from the
 company's cash whenever a tile is placed.
+
+`OperatingRoundMove` includes a `pay_dividend` flag controlling whether the
+company distributes income at the end of its turn. This flag defaults to `False`
+so most test scenarios do not need to specify it explicitly.

--- a/app/minigames/operating_round.py
+++ b/app/minigames/operating_round.py
@@ -1,6 +1,18 @@
 from typing import List, Any
 
-from app.base import PrivateCompany, Move, GameBoard, Track, Token, Route, PublicCompany, Train, Color, MutableGameState, err
+from app.base import (
+    PrivateCompany,
+    Move,
+    GameBoard,
+    Track,
+    Token,
+    Route,
+    PublicCompany,
+    Train,
+    Color,
+    MutableGameState,
+    err,
+)
 from app.minigames.base import Minigame
 
 
@@ -16,7 +28,7 @@ class OperatingRoundMove(Move):
         self.buy_train: bool \
             = None  # Will you buy a train?
         self.pay_dividend: bool \
-            = None  # Will you pay a dividend?
+            = False  # Will you pay a dividend? Defaults to False.
         self.routes: List[Route] = None
         self.public_company: PublicCompany = None
         self.token: Token = None
@@ -67,7 +79,7 @@ class OperatingRound(Minigame):
         track: Track = move.track
         board: GameBoard = kwargs.get("board")
         config = kwargs.get("config")
-        if move.construct_track and self.isValidTrackPlacement(move):
+        if move.construct_track and self.isValidTrackPlacement(move, state):
             board.setTrack(track)
             if config is not None:
                 cost = config.TRACK_LAYING_COSTS.get(track.color, 0)
@@ -147,12 +159,28 @@ class OperatingRound(Minigame):
         pc = move.public_company
         routes = move.routes or []
 
+        def parse_loc(loc: str) -> tuple:
+            """Return (row, col) tuple for board coordinates like 'A1'."""
+            if not loc:
+                return (0, 0)
+            row = ord(loc[0].upper())
+            try:
+                col = int(loc[1:])
+            except ValueError:
+                col = 0
+            return row, col
+
         has_company_token = False
         used_stops = set()
         invalid_track = False
         duplicate_stop = False
+        disconnected = False
+        capacities: List[int] = [int(''.join(filter(str.isdigit, t.type)) or 0) for t in (pc.trains or [])]
+        capacities.sort(reverse=True)
+        route_lengths = []
         for route in routes:
             route_seen = set()
+            route_lengths.append(len(route.stops))
             for stop in route.stops:
                 tokens_here = board.tokens.get(stop, []) if board else []
                 if any(t.company == pc for t in tokens_here):
@@ -166,13 +194,34 @@ class OperatingRound(Minigame):
                 route_seen.add(stop)
                 used_stops.add(stop)
 
+            if board and len(route.stops) >= 2:
+                for a, b in zip(route.stops, route.stops[1:]):
+                    if a not in board.board or b not in board.board:
+                        disconnected = True
+                        break
+                    r1, c1 = parse_loc(a)
+                    r2, c2 = parse_loc(b)
+                    if not ((r1 == r2 and abs(c1 - c2) == 1) or (c1 == c2 and abs(r1 - r2) == 1)):
+                        disconnected = True
+                        break
+
+        capacities_available = sorted(capacities, reverse=True)
+        lengths_sorted = sorted(route_lengths, reverse=True)
+        capacity_ok = len(lengths_sorted) <= len(capacities_available)
+        for length, cap in zip(lengths_sorted, capacities_available):
+            if length > cap:
+                capacity_ok = False
+                break
+
         validations = [
             err(routes != [] and all(len(r.stops) >= 2 for r in routes), "You must join at least two cities"),
             err(not invalid_track, "Route uses track that doesn't exist"),
             err(not duplicate_stop, "You cannot use the same station twice"),
+            err(not disconnected, "Route must be a continuous connection"),
             err(has_company_token, "At least one city must be occupied by that corporation's token"),
             err(pc.trains is not None and len(pc.trains) >= len(routes) and len(pc.trains) > 0,
                 "You need enough trains for the routes"),
+            err(capacity_ok, "Route length exceeds train capacity"),
         ]
 
         return self.validate(validations)
@@ -255,18 +304,30 @@ class OperatingRound(Minigame):
 
 
     @staticmethod
-    def onStart(kwargs: MutableGameState) -> None:
-        # Can non-floated companies own private companies??
-        private_companies: List[PrivateCompany] = kwargs.private_companies
+    def onStart(state: MutableGameState = None, **kwargs) -> None:
+        """Prepare the game state for a new operating round."""
+        if state is None:
+            # Allow passing the state as the sole positional argument via kwargs
+            if kwargs and isinstance(next(iter(kwargs.values())), MutableGameState):
+                state = next(iter(kwargs.values()))
+                kwargs = {}
+            else:
+                state = MutableGameState()
+
+        private_companies: List[PrivateCompany] = kwargs.get(
+            "private_companies", getattr(state, "private_companies", None)
+        )
         if private_companies:
             for pc in private_companies:
                 pc.distributeRevenue()
 
         # Reset track placement tracking for the new operating round
-        kwargs.track_laid = set()
+        state.track_laid = set()
 
-        # Reset per-round flags on public companies
-        for company in kwargs.get("public_companies", []):
+        public_companies = kwargs.get(
+            "public_companies", getattr(state, "public_companies", [])
+        )
+        for company in public_companies or []:
             company.token_placed = False
 
         # Create a list of floated companies (?)

--- a/app/unittests/OperatingRoundMinigameTests.py
+++ b/app/unittests/OperatingRoundMinigameTests.py
@@ -127,6 +127,8 @@ class OperatingRoundTrackTests(unittest.TestCase):
 
         start_cash = self.company.cash
 
+        OperatingRound.onStart(self.state)
+
         upgrade = OperatingRoundMove()
         upgrade.player_id = "A"
         upgrade.construct_track = True
@@ -189,7 +191,7 @@ class OperatingRoundTokenTests(unittest.TestCase):
         self.assertTrue(oround.run(move, self.state, board=self.board))
 
         # new operating round begins
-        OperatingRound.onStart(public_companies=[self.company], private_companies=[])
+        OperatingRound.onStart(self.state)
 
         # prepare second location
         self.board.setTrack(Track("2", "2", Color.YELLOW, "B1", 0))
@@ -323,6 +325,31 @@ class OperatingRoundRouteTests(unittest.TestCase):
         oround = OperatingRound()
         self.assertFalse(oround.run(move, self.state, board=self.board))
 
+    def test_invalid_route_exceeds_capacity(self):
+        token = Token(self.company, "A1", self.company.token_costs[0])
+        self.board.setToken(token)
+        self.board.setTrack(Track("3", "3", Color.YELLOW, "A3", 0))
+        move = OperatingRoundMove()
+        move.player_id = "A"
+        move.run_route = True
+        move.routes = [Route(["A1", "A2", "A3"])]
+        move.public_company = self.company
+        oround = OperatingRound()
+        self.assertFalse(oround.run(move, self.state, board=self.board))
+
+    def test_invalid_route_not_continuous(self):
+        token = Token(self.company, "A1", self.company.token_costs[0])
+        self.board.setToken(token)
+        self.board.setTrack(Track("3", "3", Color.YELLOW, "A3", 0))
+        self.company.trains.append(Train("3", 180))
+        move = OperatingRoundMove()
+        move.player_id = "A"
+        move.run_route = True
+        move.routes = [Route(["A1", "A3"])]
+        move.public_company = self.company
+        oround = OperatingRound()
+        self.assertFalse(oround.run(move, self.state, board=self.board))
+
 
 class OperatingRoundPaymentOptionTests(unittest.TestCase):
     def setUp(self):
@@ -366,6 +393,14 @@ class OperatingRoundPaymentOptionTests(unittest.TestCase):
         oround.run(move, self.state, board=self.board)
         self.assertEqual(self.state.players[0].cash, 1000 + 20)
         self.assertEqual(self.company._income, 0)
+
+    def test_payment_option_defaults_false(self):
+        move = OperatingRoundMove()
+        move.player_id = "A"
+        move.public_company = self.company
+        oround = OperatingRound()
+        self.assertTrue(oround.run(move, self.state, board=self.board))
+        self.assertFalse(move.pay_dividend)
 
 
 class OperatingRoundTrainPurchaseTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- default `OperatingRoundMove.pay_dividend` to `False`
- document the default dividend behaviour in project READMEs
- adjust operating round initialization helper to accept a state parameter
- fix tests to call `OperatingRound.onStart` correctly and add a test for the new default

## Testing
- `python -m unittest app.unittests.OperatingRoundMinigameTests -v`