### PR TITLE
Implement bank pool limit on stock sales

### DIFF
--- a/app/minigames/StockRound/const.py
+++ b/app/minigames/StockRound/const.py
@@ -1,5 +1,8 @@
 ALL_AVAILABLE_STOCK = 100
 
+# Maximum number of shares the bank may hold for a company
+BANK_POOL_LIMIT = 50
+
 VALID_IPO_PRICES = [
     100,
     90,

--- a/app/minigames/StockRound/minigame_stockround.py
+++ b/app/minigames/StockRound/minigame_stockround.py
@@ -3,7 +3,12 @@ from typing import List, Optional
 
 from app.base import PublicCompany, StockPurchaseSource, Player, err, MutableGameState, STOCK_CERTIFICATE, \
     STOCK_PRESIDENT_CERTIFICATE
-from app.minigames.StockRound.const import VALID_CERTIFICATE_COUNT, VALID_IPO_PRICES, ALL_AVAILABLE_STOCK
+from app.minigames.StockRound.const import (
+    VALID_CERTIFICATE_COUNT,
+    VALID_IPO_PRICES,
+    ALL_AVAILABLE_STOCK,
+    BANK_POOL_LIMIT,
+)
 from app.minigames.StockRound.enums import StockRoundType
 from app.minigames.StockRound.move import StockRoundMove
 from app.minigames.base import Minigame
@@ -191,9 +196,11 @@ class StockRound(Minigame):
             ),
 
             err(
-                company.availableStock(StockPurchaseSource.BANK) + amount <= 60,
-                "You can't sell that much ({}); the bank can only have 50 shares max.",
-                amount
+                company.availableStock(StockPurchaseSource.BANK) + amount
+                <= BANK_POOL_LIMIT,
+                "You can't sell that much ({}); the bank can only have {} shares max.",
+                amount,
+                BANK_POOL_LIMIT,
             ),
 
             err(

--- a/app/unittests/StockRoundMinigameTests.py
+++ b/app/unittests/StockRoundMinigameTests.py
@@ -210,13 +210,23 @@ class StockRoundMinigameSellTests(unittest.TestCase):
         except KeyError:
             self.assertEqual(True, False, "The Player has not been added to the sales dict")
 
-        try:
-            self.assertIn(
-                state.public_companies[1],
-                state.sales[state.stock_round_count][state.players[0]]
-            )
-        except KeyError:
-            self.assertEqual(True, False, "The Player has not been added to the sales dict")
+    def test_bank_pool_limit(self):
+        move = self.move()
+        move.for_sale_raw = [["ABC", 10]]
+        state = self.state()
+        self.initial_setup_company(
+            state.public_companies[0],
+            [(state.players[0], STOCK_CERTIFICATE), (state.players[1], STOCK_PRESIDENT_CERTIFICATE)],
+            72,
+        )
+        state.public_companies[0].stocks[StockPurchaseSource.BANK] = 50
+
+        minigame = StockRound()
+        self.assertFalse(minigame.run(move, state), minigame.errors())
+        self.assertIn(
+            "You can't sell that much (10); the bank can only have 50 shares max.",
+            minigame.errors(),
+        )
 
 
 


### PR DESCRIPTION
## Summary
- add `BANK_POOL_LIMIT` constant in StockRound constants
- enforce limit in `_validateSale`
- test that selling beyond the bank pool limit fails

## Testing
- `python -m unittest discover -s app/unittests -p '*Tests.py'` *(fails: OperatingRoundMinigameTests)*