### PR TITLE
Update StockRoundSellPrivateCompany rules

### DIFF
--- a/app/minigames/StockRoundSellPrivateCompany/README.md
+++ b/app/minigames/StockRoundSellPrivateCompany/README.md
@@ -1,14 +1,41 @@
-Private Company Auction During Stock Round
-------------------------------------------
+Private Company Sale to Another Player
+-------------------------------------
+
+Rule `4.1` of the 1830 rulebook states that a player may sell one of their
+private companies to another player during either participant's stock-round
+turn for any mutually agreed price. Such sales are not permitted in the first
+stock round. Selling a private company into a corporation occurs during an
+operating round after a 3-train is purchased and is outside the scope of this
+minigame.
+
+This implementation handles the player-to-player transaction as a short auction.
+The seller offers a company and each opponent may bid or pass. Once everyone has
+responded the seller can accept one bid or reject them all. Bids may be for any
+amount; this follows rule `4.1` allowing the two players to agree on any price.
 
 Technical Explanation
 ---------------------
 
+The `StockRoundSellPrivateCompany` minigame has two phases. `Auction` collects
+bids from the other players and stores them on the game state. When all have
+acted, `AuctionDecision` lets the selling player accept one bid or reject them
+all. Cash is exchanged and ownership updated if a bid is accepted.
+
 Auction
 -------
+
+Handles the bidding step. Each opponent may either bid any non-negative amount
+or pass. When all have acted the minigame proceeds to `AuctionDecision`.
 
 AuctionDecision
 ---------------
 
+The owner reviews the offers and either accepts one or rejects them all. If a
+bid is accepted the funds transfer immediately and play returns to the stock
+round.
+
 Transition to Stock Round
-------------------------- 
+-------------------------
+
+After `AuctionDecision` resolves, control returns to `StockRound` so the next
+player may act.

--- a/app/minigames/StockRoundSellPrivateCompany/minigame_auction.py
+++ b/app/minigames/StockRoundSellPrivateCompany/minigame_auction.py
@@ -30,6 +30,10 @@ class Auction(Minigame):
     def validatePass(self, move: AuctionBidMove, state: MutableGameState):
         return self.validate([
             err(
+                state.stock_round_count > 1,
+                "You can't sell a private company in the first stock round."
+            ),
+            err(
                 move.player != state.auctioned_private_company.belongs_to,
                 "You can't pass (or bid) on your own company.",
                 move.private_company.name,
@@ -39,6 +43,10 @@ class Auction(Minigame):
 
     def validateBid(self, move: AuctionBidMove, state: MutableGameState):
         return self.validate([
+            err(
+                state.stock_round_count > 1,
+                "You can't sell a private company in the first stock round."
+            ),
             err(
                 move.player.hasEnoughMoney(move.amount),
                 "You cannot afford poorboi. {} (You have: {})",
@@ -55,15 +63,8 @@ class Auction(Minigame):
                 move.private_company.name,
                 state.auctioned_private_company.name
             ), err(
-                move.amount >= int(state.auctioned_private_company.cost / 2),
-                "You are paying too little.  Your bid must be 1/2 to 2 times the price of the company ({} to {}).",
-                int(move.private_company.cost / 2),
-                move.private_company.cost * 2
-            ), err(
-                move.amount <= int(state.auctioned_private_company.cost * 2),
-                "You are paying too much.  Your bid must be 1/2 to 2 times the price of the company ({} to {}).",
-                int(move.private_company.cost / 2),
-                move.private_company.cost * 2
+                move.amount >= 0,
+                "Bid must be non-negative."
             ),
 
         ]

--- a/app/minigames/StockRoundSellPrivateCompany/minigame_decision.py
+++ b/app/minigames/StockRoundSellPrivateCompany/minigame_decision.py
@@ -41,6 +41,10 @@ class AuctionDecision(Minigame):
         """
         return self.validate([
             err(
+                state.stock_round_count > 1,
+                "You can't sell a private company in the first stock round."
+            ),
+            err(
                 move.accepted_player_id in [player_id for player_id, amount in state.auction],
                 """You are accepting a bid from a player who didn't make a bid. (ID: "{}")""",
                 move.accepted_player_id
@@ -57,6 +61,10 @@ class AuctionDecision(Minigame):
 
     def validateReject(self, move: AuctionDecisionMove, state: MutableGameState):
         return self.validate([
+            err(
+                state.stock_round_count > 1,
+                "You can't sell a private company in the first stock round."
+            ),
             err(
                 move.player == move.private_company.belongs_to,
                 """You can't reject an auction if you do not own the company.""",

--- a/app/unittests/SellPrivateCompanyAuctionTests.py
+++ b/app/unittests/SellPrivateCompanyAuctionTests.py
@@ -36,7 +36,7 @@ class AuctionRejectDecisionTests(unittest.TestCase):
         game_context.auctioned_private_company.belongs_to = game_context.players[5]
         game_context.auction = []
 
-        game_context.stock_round_count = 1
+        game_context.stock_round_count = 2
         game_context.sales = [{},{}]
         game_context.purchases = [{},{}]
         return game_context
@@ -88,7 +88,7 @@ class AuctionAcceptDecisionTests(unittest.TestCase):
         game_context.auctioned_private_company.belongs_to = game_context.players[5]
         game_context.auction = []
 
-        game_context.stock_round_count = 1
+        game_context.stock_round_count = 2
         game_context.sales = [{},{}]
         game_context.purchases = [{},{}]
         return game_context
@@ -150,8 +150,7 @@ class AuctionAcceptDecisionTests(unittest.TestCase):
         self.assertEqual(state.stock_round_play, self.state().stock_round_play)
 
     def testPlayerNoFreebies(self):
-        """0$ bids are supposed to indicate a player has passed.  You can't accept those kinds of bids.
-        Other kinds of bids (less than 1/2, greater than 2x) cannot be added so we don't have to test those"""
+        """Zero-dollar bids represent a pass and may not be accepted"""
         move = self.move()
         state = self.state()
         state.auction.append(("B", 0))
@@ -185,7 +184,7 @@ class AuctionPassTests(unittest.TestCase):
         game_context.auctioned_private_company.belongs_to = game_context.players[5]
         game_context.auction = []
 
-        game_context.stock_round_count = 1
+        game_context.stock_round_count = 2
         game_context.sales = [{},{}]
         game_context.purchases = [{},{}]
         return game_context
@@ -238,13 +237,13 @@ class AuctionBidTests(unittest.TestCase):
         game_context.auctioned_private_company.belongs_to = game_context.players[5]
         game_context.auction = []
 
-        game_context.stock_round_count = 1
+        game_context.stock_round_count = 2
         game_context.sales = [{},{}]
         game_context.purchases = [{},{}]
         return game_context
 
     def testPlayerValidBid(self):
-        """Valid bid within the min / max bid values"""
+        """Valid bid succeeds when player can afford it"""
         move = self.bid(250)
         state = self.state()
 
@@ -252,7 +251,7 @@ class AuctionBidTests(unittest.TestCase):
         self.assertTrue(minigame.run(move, state), minigame.errors())
 
     def testPlayerInsufficientCashBid(self):
-        """Player don't have enough cash to bid this much."""
+        """Player doesn't have enough cash to bid this much."""
         move = self.bid(650)
         state = self.state()
 
@@ -260,6 +259,19 @@ class AuctionBidTests(unittest.TestCase):
         self.assertFalse(minigame.run(move, state), minigame.errors())
         self.assertIn(
             "You cannot afford poorboi. 650 (You have: 500)",
+            minigame.errors()
+        )
+
+    def testBidFirstStockRoundNotAllowed(self):
+        """Cannot sell private companies in the first stock round"""
+        move = self.bid(250)
+        state = self.state()
+        state.stock_round_count = 1
+
+        minigame = Auction()
+        self.assertFalse(minigame.run(move, state), minigame.errors())
+        self.assertIn(
+            "You can't sell a private company in the first stock round.",
             minigame.errors()
         )
 
@@ -291,27 +303,23 @@ class AuctionBidTests(unittest.TestCase):
             minigame.errors()
         )
 
-    def testPlayerBidTooSmall(self):
+    def testPlayerSmallBidAllowed(self):
+        """Bids below face value are permitted"""
         move = self.bid(1)
         state = self.state()
 
         minigame = Auction()
-        # You can't bid on a company that is not up for auction
-        self.assertFalse(minigame.run(move, state), minigame.errors())
-        self.assertIn(
-            "You are paying too little.  Your bid must be 1/2 to 2 times the price of the company (125 to 500).",
-            minigame.errors()
-        )
+        self.assertTrue(minigame.run(move, state), minigame.errors())
 
     def testPlayerBidTooLarge(self):
+        """Bid fails if player lacks cash"""
         move = self.bid(1000)
         state = self.state()
 
         minigame = Auction()
-        # You can't bid on a company that is not up for auction
         self.assertFalse(minigame.run(move, state), minigame.errors())
         self.assertIn(
-            "You are paying too much.  Your bid must be 1/2 to 2 times the price of the company (125 to 500).",
+            "You cannot afford poorboi. 1000 (You have: 500)",
             minigame.errors()
         )
 


### PR DESCRIPTION
## Summary
- allow private company sales at any price
- disallow sales in the first stock round
- document rule 4.1 and unrestricted bids
- update unit tests for new behaviour

## Testing
- `python -m pytest`
- `python -m unittest discover`
