### PR TITLE
Enforce company ownership cap

### DIFF
--- a/app/minigames/StockRound/minigame_stockround.py
+++ b/app/minigames/StockRound/minigame_stockround.py
@@ -168,6 +168,12 @@ class StockRound(Minigame):
                 VALID_CERTIFICATE_COUNT[number_of_total_players],
                 player_certificates),
             err(
+                move.player.hasStock(move.public_company) +
+                (STOCK_PRESIDENT_CERTIFICATE if self.isFirstPurchase(move) else STOCK_CERTIFICATE)
+                <= 60,
+                "You can't own more than 60% of a company {} {}",
+                move.public_company.id, move.public_company.name),
+            err(
                 move.public_company.hasStock(move.source, STOCK_CERTIFICATE),
                 "The company does not have enough stock in category {}",
                 move.source),

--- a/app/unittests/test_StockRoundMinigame.py
+++ b/app/unittests/test_StockRoundMinigame.py
@@ -126,6 +126,32 @@ class StockRoundMinigameBuyTests(unittest.TestCase):
         except KeyError:
             self.assertEqual(True, False, "The Player has not been added to the purchases dict")
 
+    def test_player_cannot_exceed_sixty_percent(self):
+        move = self.move()
+        state = self.state()
+        state.players[0].cash = 10000
+        state.public_companies[0].setInitialPrice(72)
+        state.public_companies[0].buy(state.players[0], StockPurchaseSource.IPO, 60)
+
+        minigame = StockRound()
+        self.assertFalse(minigame.run(move, state), minigame.errors())
+        self.assertEqual(state.public_companies[0].owners[state.players[0]], 60)
+        self.assertIn(
+            "You can't own more than 60% of a company ABC Fake company ABC",
+            minigame.errors(),
+        )
+
+    def test_player_can_buy_up_to_sixty_percent(self):
+        move = self.move()
+        state = self.state()
+        state.players[0].cash = 10000
+        state.public_companies[0].setInitialPrice(72)
+        state.public_companies[0].buy(state.players[0], StockPurchaseSource.IPO, 50)
+
+        minigame = StockRound()
+        self.assertTrue(minigame.run(move, state), minigame.errors())
+        self.assertEqual(state.public_companies[0].owners[state.players[0]], 60)
+
 
 class StockRoundMinigameSellTests(unittest.TestCase):
     def move(self) -> StockRoundMove:


### PR DESCRIPTION
## Summary
- prevent purchases that would put a player above 60% ownership in a company
- test exceeding the 60% cap
- test buying up to 60%

## Testing
- `python -m unittest discover`