### PR TITLE
Implement stock market grid movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ during the operating round.
 
 * If you sell shares of a company during a stock round, you cannot buy shares in
   that same company again until the next stock round begins.
+* Stock prices now move on a 12×5 grid. Each space has a band colour and
+  optional arrows. Dividends move the marker right (or up-right in brown),
+  withholds move left and share sales push the price down. Reaching the board
+  edge simply stops further movement in that direction.

--- a/app/config/1830.py
+++ b/app/config/1830.py
@@ -1,4 +1,13 @@
-from app.base import PrivateCompany, PublicCompany, Train, Color
+from app.base import (
+    PrivateCompany,
+    PublicCompany,
+    Train,
+    Color,
+    Cell,
+    StockMarket,
+    Band,
+    Direction,
+)
 
 
 def starting_cash(num_players: int) -> int:
@@ -37,8 +46,22 @@ PUBLIC_COMPANIES = [
                            tokens_available=4, token_costs=[40, 60, 80, 100]),
 ]
 
-# Placeholder data for future rules
-STOCK_MARKET = []
+# Simplified 12x5 stock market grid with a few coloured cells
+STOCK_MARKET_GRID: list[list[Cell]] = []
+for r in range(5):
+    row = []
+    for c in range(12):
+        band = Band.WHITE
+        arrow = None
+        if (r, c) == (2, 2):
+            band = Band.YELLOW
+        if (r, c) == (1, 1):
+            band = Band.BROWN
+            arrow = Direction.UP_RIGHT
+        row.append(Cell(10 * (c + 1), band, arrow))
+    STOCK_MARKET_GRID.append(row)
+
+STOCK_MARKET = StockMarket(STOCK_MARKET_GRID)
 TRAINS = [Train("2", 80, rusts_on="4"), Train("3", 180, rusts_on="5")]
 OPERATING_ROUNDS = 2
 

--- a/app/unittests/test_stock_market_movement.py
+++ b/app/unittests/test_stock_market_movement.py
@@ -1,0 +1,56 @@
+import unittest
+
+from app.base import StockMarket, Cell, Band, Direction
+from app.unittests.test_StockRoundMinigame import fake_public_company
+
+
+class StockMarketMovementTests(unittest.TestCase):
+    def setUp(self):
+        grid = []
+        for r in range(5):
+            row = []
+            for c in range(12):
+                band = Band.WHITE
+                arrow = None
+                if (r, c) == (2, 2):
+                    band = Band.YELLOW
+                if (r, c) == (1, 1):
+                    band = Band.BROWN
+                    arrow = Direction.UP_RIGHT
+                row.append(Cell(10 * (c + 1), band, arrow))
+            grid.append(row)
+        self.market = StockMarket(grid)
+
+    def test_sale_multiple_rows_down(self):
+        company = fake_public_company("PRR")
+        company.attach_market(self.market, 3, 5)
+        company.priceDown(30)
+        self.assertEqual(company.stock_pos, (4, 5))
+
+    def test_withhold_yellow_moves_left(self):
+        company = fake_public_company("NYC")
+        company.attach_market(self.market, 2, 2)
+        self.market.on_withhold(company)
+        self.assertEqual(company.stock_pos, (2, 1))
+
+    def test_dividend_brown_up_right(self):
+        company = fake_public_company("B&O")
+        company.attach_market(self.market, 1, 1)
+        self.market.on_payout(company)
+        self.assertEqual(company.stock_pos, (0, 2))
+
+    def test_sold_out_bump_ignored_top(self):
+        company = fake_public_company("ERIE")
+        company.attach_market(self.market, 0, 5)
+        self.market.on_sold_out(company)
+        self.assertEqual(company.stock_pos, (0, 5))
+
+    def test_left_edge_withhold_ignored(self):
+        company = fake_public_company("C&O")
+        company.attach_market(self.market, 2, 0)
+        self.market.on_withhold(company)
+        self.assertEqual(company.stock_pos, (2, 0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- rebuild StockMarket to use 12×5 grid with directional movement
- track corporation position with `stock_pos` and update on events
- define basic grid for 1830 configuration
- revise README explanation of price movement
- add tests covering sale, withhold and dividend scenarios

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_683a842a45c88320a1b86b63b8fff158