### PR TITLE
Add player name prompt and game lobby UI

### DIFF
--- a/multiplayer/frontend/src/app.ts
+++ b/multiplayer/frontend/src/app.ts
@@ -13,12 +13,14 @@ import { HexMap } from './components/HexMap';
 import { ActionTicker } from './components/ActionTicker';
 import { PlayerList } from './components/PlayerList';
 import { LobbyModal } from './components/LobbyModal';
+import { GameLobby } from './components/GameLobby';
 
 export class App {
   private appContainer: HTMLElement;
   private authState: AuthState = { authenticated: false };
   private gameState: GameState | null = null;
   private currentTab: string = 'map';
+  private gameLobby: GameLobby | null = null;
 
   // UI Components
   private header: Header;
@@ -183,8 +185,13 @@ export class App {
       this.authState.authenticated = true;
       this.authState.authType = data.auth_type;
 
-      // Build main UI
-      this.buildMainUI();
+      // If player, prompt for name first
+      if (data.auth_type === 'player') {
+        this.promptForPlayerName();
+      } else {
+        // Creator or spectator - show lobby
+        this.showGameLobby(data.game);
+      }
 
       // Request current game state
       socketService.requestGameState();
@@ -195,6 +202,9 @@ export class App {
       console.log('🎮 Game started');
       soundEffects.playSuccess();
       this.gameState = data.game_state;
+
+      // Switch from lobby to game UI
+      this.buildMainUI();
       this.updateUI();
     });
 
@@ -212,6 +222,18 @@ export class App {
 
     socketService.on('player_joined', (data) => {
       console.log('👤 Player joined:', data);
+
+      // If this is us joining, show the lobby
+      if (data.player_name && this.authState.authType === 'player' && !this.gameLobby) {
+        this.showGameLobby({ room_code: this.authState.roomCode, max_players: 6 });
+      }
+
+      // Update lobby if visible
+      if (this.gameLobby) {
+        this.gameLobby.updatePlayers(data.players);
+      }
+
+      // Update player list
       this.updatePlayerList(data.players);
     });
 
@@ -380,5 +402,76 @@ export class App {
     setTimeout(() => {
       errorDiv.remove();
     }, 5000);
+  }
+
+  private promptForPlayerName() {
+    this.appContainer.innerHTML = '';
+
+    const container = document.createElement('div');
+    container.className = 'lobby-container';
+    container.innerHTML = `
+      <h1 class="lobby-title">🚂 Welcome to 1889!</h1>
+
+      <div style="max-width: 500px; margin: 0 auto; background: var(--background-tertiary); padding: 40px; border-radius: 12px;">
+        <h2 style="margin-bottom: 20px;">Enter Your Name</h2>
+
+        <div class="form-group">
+          <label class="form-label">Player Name:</label>
+          <input type="text" id="player-name-input" class="form-input"
+                 placeholder="Enter your name..."
+                 maxlength="20"
+                 autofocus>
+        </div>
+
+        <button id="set-name-btn" style="width: 100%;">Join Game</button>
+
+        <p style="margin-top: 20px; font-size: 14px; color: var(--text-secondary);">
+          Choose a name that other players will see during the game.
+        </p>
+      </div>
+    `;
+
+    this.appContainer.appendChild(container);
+
+    const input = container.querySelector('#player-name-input') as HTMLInputElement;
+    const button = container.querySelector('#set-name-btn') as HTMLButtonElement;
+
+    const submitName = () => {
+      const name = input.value.trim();
+      if (name) {
+        socketService.joinGame(name);
+        this.showLoading('Joining game lobby...');
+      }
+    };
+
+    button.addEventListener('click', submitName);
+    input.addEventListener('keypress', (e) => {
+      if (e.key === 'Enter') {
+        submitName();
+      }
+    });
+  }
+
+  private async showGameLobby(game: any) {
+    this.appContainer.innerHTML = '';
+
+    // Fetch current players
+    const response = await fetch(`/api/games/${game.room_code}`);
+    const gameData = await response.json();
+
+    this.gameLobby = new GameLobby({
+      maxPlayers: game.max_players,
+      isCreator: this.authState.authType === 'creator',
+      onStartGame: (playerNames: string[]) => {
+        socketService.startGame(playerNames);
+        this.showLoading('Starting game...');
+      }
+    });
+
+    this.appContainer.appendChild(this.gameLobby.render());
+
+    if (gameData.players) {
+      this.gameLobby.updatePlayers(gameData.players);
+    }
   }
 }

--- a/multiplayer/frontend/src/components/GameLobby.ts
+++ b/multiplayer/frontend/src/components/GameLobby.ts
@@ -1,0 +1,181 @@
+/**
+ * Game Lobby component - shows players waiting and allows starting the game
+ */
+
+export class GameLobby {
+  private element: HTMLElement | null = null;
+  private players: any[] = [];
+  private maxPlayers: number = 6;
+  private isCreator: boolean = false;
+  private onStartGame?: (playerNames: string[]) => void;
+
+  constructor(options: {
+    maxPlayers: number;
+    isCreator: boolean;
+    onStartGame?: (playerNames: string[]) => void;
+  }) {
+    this.maxPlayers = options.maxPlayers;
+    this.isCreator = options.isCreator;
+    this.onStartGame = options.onStartGame;
+  }
+
+  render(): HTMLElement {
+    const container = document.createElement('div');
+    container.className = 'lobby-container';
+    container.id = 'game-lobby';
+
+    container.innerHTML = `
+      <h1 class="lobby-title">🚂 Game Lobby</h1>
+
+      <div style="background: var(--background-tertiary); padding: 20px; border-radius: 12px; margin-bottom: 20px;">
+        <h3 style="margin-bottom: 15px;">Waiting for Players...</h3>
+        <div class="player-slots" id="player-slots">
+          ${this.renderPlayerSlots()}
+        </div>
+      </div>
+
+      ${this.isCreator ? `
+        <div style="background: var(--background-tertiary); padding: 20px; border-radius: 12px;">
+          <h3 style="margin-bottom: 15px;">Creator Controls</h3>
+
+          <div class="form-group">
+            <label class="form-label">Number of Players:</label>
+            <select id="active-player-count" class="form-input">
+              <option value="3">3 Players</option>
+              <option value="4">4 Players</option>
+              <option value="5">5 Players</option>
+              <option value="6" selected>6 Players</option>
+            </select>
+            <p style="font-size: 12px; color: var(--text-secondary); margin-top: 8px;">
+              Only the selected number of players will be used. Empty slots will be ignored.
+            </p>
+          </div>
+
+          <button id="start-game-btn" style="width: 100%;" disabled>
+            Start Game (Waiting for players...)
+          </button>
+
+          <p style="margin-top: 15px; font-size: 14px; color: var(--text-secondary);">
+            Need at least 3 players with names to start.
+          </p>
+        </div>
+      ` : `
+        <div style="text-align: center; padding: 20px; background: var(--background-tertiary); border-radius: 12px;">
+          <p style="font-size: 16px;">Waiting for the game creator to start...</p>
+        </div>
+      `}
+    `;
+
+    this.element = container;
+    this.setupEventListeners();
+    return container;
+  }
+
+  private renderPlayerSlots(): string {
+    const slots = [];
+    for (let i = 0; i < this.maxPlayers; i++) {
+      const player = this.players[i];
+      const isPending = player && player.player_name.includes('(pending)');
+      const hasName = player && !isPending;
+
+      slots.push(`
+        <div class="player-slot ${hasName ? 'filled' : 'empty'}">
+          <div style="display: flex; align-items: center; justify-content: space-between;">
+            <div>
+              <strong>Player ${i + 1}:</strong>
+              ${hasName ? `
+                <span style="color: var(--success-color); margin-left: 10px;">
+                  ${this.escapeHtml(player.player_name)} ✓
+                </span>
+              ` : isPending ? `
+                <span style="color: var(--warning-color); margin-left: 10px;">
+                  Connected (setting name...)
+                </span>
+              ` : `
+                <span style="color: var(--text-secondary); margin-left: 10px;">
+                  Empty
+                </span>
+              `}
+            </div>
+          </div>
+        </div>
+      `);
+    }
+    return slots.join('');
+  }
+
+  updatePlayers(players: any[]) {
+    this.players = players.sort((a, b) => a.player_order - b.player_order);
+    this.refresh();
+  }
+
+  private refresh() {
+    if (!this.element) return;
+
+    const slotsContainer = this.element.querySelector('#player-slots');
+    if (slotsContainer) {
+      slotsContainer.innerHTML = this.renderPlayerSlots();
+    }
+
+    // Update start button state
+    if (this.isCreator) {
+      const startBtn = this.element.querySelector('#start-game-btn') as HTMLButtonElement;
+      const playerCountSelect = this.element.querySelector('#active-player-count') as HTMLSelectElement;
+
+      if (startBtn && playerCountSelect) {
+        const targetCount = parseInt(playerCountSelect.value);
+        const readyPlayers = this.players.filter(p => !p.player_name.includes('(pending)')).slice(0, targetCount);
+        const canStart = readyPlayers.length >= 3 && readyPlayers.length >= targetCount;
+
+        startBtn.disabled = !canStart;
+        if (canStart) {
+          startBtn.textContent = `Start Game with ${readyPlayers.length} Players`;
+        } else {
+          startBtn.textContent = `Start Game (Need ${targetCount - readyPlayers.length} more players)`;
+        }
+      }
+    }
+  }
+
+  private setupEventListeners() {
+    if (!this.element || !this.isCreator) return;
+
+    const startBtn = this.element.querySelector('#start-game-btn');
+    const playerCountSelect = this.element.querySelector('#active-player-count');
+
+    if (startBtn) {
+      startBtn.addEventListener('click', () => {
+        this.handleStartGame();
+      });
+    }
+
+    if (playerCountSelect) {
+      playerCountSelect.addEventListener('change', () => {
+        this.refresh();
+      });
+    }
+  }
+
+  private handleStartGame() {
+    if (!this.onStartGame || !this.element) return;
+
+    const playerCountSelect = this.element.querySelector('#active-player-count') as HTMLSelectElement;
+    const targetCount = parseInt(playerCountSelect.value);
+
+    // Get players with names (not pending)
+    const readyPlayers = this.players
+      .filter(p => !p.player_name.includes('(pending)'))
+      .slice(0, targetCount)
+      .map(p => p.player_name);
+
+    if (readyPlayers.length >= 3) {
+      this.onStartGame(readyPlayers);
+    }
+  }
+
+  private escapeHtml(text: string): string {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  }
+}


### PR DESCRIPTION
Fixes for missing UI elements:

Frontend improvements:
1. Added GameLobby component showing:
   - All player slots with status (filled/pending/empty)
   - Creator controls to select player count (3-6)
   - Dynamic start button that enables when enough players have joined
   - Real-time updates as players join

2. Added player name prompt:
   - Players are now prompted to enter their name after authentication
   - Simple form with validation
   - Calls join_game socket event with the name

3. Updated app flow:
   - Player: authenticate → enter name → join lobby → wait for game start
   - Creator: authenticate → see lobby → manage player count → start game
   - Game start switches from lobby to main game UI

4. Lobby features:
   - Shows which slots are filled vs. empty
   - Displays pending players (connected but haven't set name)
   - Creator can select how many players (3-6) to start with
   - Start button only enables when enough players are ready

5. Visual feedback:
   - Green checkmark for joined players
   - Orange warning for pending players
   - Gray for empty slots
   - Dynamic button text showing how many more players needed

This addresses all three issues:
- Players can now input their name
- Player list updates in real-time
- Creator can easily select player count before starting